### PR TITLE
feat: MQTT keep alive and QoS

### DIFF
--- a/lib/src/platform_mq.dart
+++ b/lib/src/platform_mq.dart
@@ -39,7 +39,7 @@ class PlatformMQImpl implements PlatformMQ {
     // action in Dash or Platform.
     _client
       ..autoReconnect = true
-      ..keepAlivePeriod = 60
+      ..keepAlivePeriod = 30
       ..setProtocolV311()
       ..websocketProtocols = ['mqttv3.1.1']
       ..onAutoReconnect = _handleAutoReconnect

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -91,8 +91,8 @@ class KurentoRoom extends ChangeNotifier implements Room {
 
   Future<void> _init() async {
     // Asynchronously subscribe to the room-related topics.
-    await _mq.subscribe(_serviceRequestPresenceTopic, MqttQos.atLeastOnce, _handleServiceRequestPresenceMessage);
-    await _mq.subscribe(_participantTopic, MqttQos.atLeastOnce, _handleParticipantMessage);
+    await _mq.subscribe(_serviceRequestPresenceTopic, MqttQos.atMostOnce, _handleServiceRequestPresenceMessage);
+    await _mq.subscribe(_participantTopic, MqttQos.atMostOnce, _handleParticipantMessage);
 
     // If messaging is supported, subscribe to the message channel.
     if (_pubnub != null) {
@@ -357,13 +357,13 @@ class KurentoRoom extends ChangeNotifier implements Room {
         trackId,
         _serviceRequest.participantId,
         {'candidate': candidate.candidate, 'sdpMid': candidate.sdpMid, 'sdpMLineIndex': candidate.sdpMLineIndex});
-    _mq.publish(_roomTopic, MqttQos.atLeastOnce, jsonEncode(message.toJson()));
+    _mq.publish(_roomTopic, MqttQos.atMostOnce, jsonEncode(message.toJson()));
   }
 
   void _handleSdpOffer(int trackId, RTCSessionDescription sessionDescription) {
     ParticipantMessage message = ParticipantMessage(ParticipantMessageType.SDP_OFFER, trackId,
         _serviceRequest.participantId, {'type': sessionDescription.type, 'sdp': sessionDescription.sdp});
-    _mq.publish(_roomTopic, MqttQos.atLeastOnce, jsonEncode(message.toJson()));
+    _mq.publish(_roomTopic, MqttQos.atMostOnce, jsonEncode(message.toJson()));
   }
 
   void _handleTrack(int trackId, RTCTrackEvent event) {


### PR DESCRIPTION
This change reduces the MQTT keep alive from `60` to `30` seconds. At `60`, we're seeing disconnects about once a minute:

<img width="584" alt="Screen Shot 2022-04-28 at 9 37 50 PM" src="https://user-images.githubusercontent.com/1007109/165885950-b6407050-f13d-4f9a-92b0-e90735d34a4b.png">

I don't know why yet, but at `30` those don't seem to happen. 🤷🏾 

This also changes the quality of service (QoS) from at most once (1) to at least once (0). After reading more about MQTT [QoS levels](https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/), it doesn't really make sense to use QoS 1 if the other clients (Platform and Dash) are using QoS 0. We'll stick with QoS 0 for now (same as the legacy apps) until we have a chance to revisit QoS end-to-end.