### PR TITLE
feat: feedback version 2

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,7 +12,7 @@ void main() {
 
   // Auto-enable accessibility for our Blind and Low Vision customers (see
   // https://docs.flutter.dev/development/accessibility-and-localization/accessibility#screen-readers).
-  RendererBinding.instance!.setSemanticsEnabled(true);
+  RendererBinding.instance.setSemanticsEnabled(true);
 
   // Configure logging.
   Logger.root.level = Level.INFO;

--- a/lib/flutter_aira.dart
+++ b/lib/flutter_aira.dart
@@ -1,4 +1,4 @@
-export 'src/models/feedback.dart' show Feedback, Rating;
+export 'src/models/feedback.dart' show AgentFeedback, Feedback, Rating;
 export 'src/models/message.dart' show Message;
 export 'src/models/participant.dart' show Participant, ParticipantStatus;
 export 'src/models/service_request.dart' show ServiceRequest, ServiceRequestState;

--- a/lib/src/models/feedback.dart
+++ b/lib/src/models/feedback.dart
@@ -23,14 +23,26 @@ class Feedback {
   String? comment;
   Rating? rating;
   final Set<String> tags = {};
-  bool shareable = false;
 
   Map<String, dynamic> toJson() {
     return {
       'comment': comment,
       'rating': rating?.value,
       'tags': tags.toList(growable: false),
-      'shareable': shareable,
+    };
+  }
+}
+
+class AgentFeedback extends Feedback {
+  bool requestReview = false;
+  bool shareKudos = false;
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      ...super.toJson(),
+      'requestReview': requestReview,
+      'shareKudos': shareKudos,
     };
   }
 }

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -238,13 +238,13 @@ class PlatformClient {
 
   /// Saves feedback for a service request.
   Future<void> saveFeedback(int serviceRequestId,
-      {Feedback? agentFeedback, Feedback? appFeedback, Feedback? offerFeedback}) async {
+      {AgentFeedback? agentFeedback, Feedback? appFeedback, Feedback? offerFeedback}) async {
     _verifyIsLoggedIn();
 
     String body = jsonEncode({
       'serviceId': serviceRequestId,
       'comment': jsonEncode({
-        'schemaVersion': 1,
+        'schemaVersion': 2,
         'agent': agentFeedback?.toJson(),
         'app': appFeedback?.toJson(),
         'offer': offerFeedback?.toJson(),


### PR DESCRIPTION
This bumps the `schemaVersion` of feedback from `1` to `2`. `shareable` has been removed; instead, `requestReview` and `shareKudos` have been added to the new `AgentFeedback` class.

![image](https://user-images.githubusercontent.com/1007109/168696960-2d7c9ef0-c7a6-4c3f-b6f7-1c7c9ae77195.png)
