### PR TITLE
feat!: add `PlatformClient.createAccount`

### DIFF
--- a/lib/flutter_aira.dart
+++ b/lib/flutter_aira.dart
@@ -1,3 +1,4 @@
+export 'src/models/credentials.dart' show Credentials;
 export 'src/models/feedback.dart' show AgentFeedback, Feedback, Rating;
 export 'src/models/message.dart' show Message;
 export 'src/models/participant.dart' show Participant, ParticipantStatus;

--- a/lib/flutter_aira.dart
+++ b/lib/flutter_aira.dart
@@ -2,6 +2,7 @@ export 'src/models/credentials.dart' show Credentials;
 export 'src/models/feedback.dart' show AgentFeedback, Feedback, Rating;
 export 'src/models/message.dart' show Message;
 export 'src/models/participant.dart' show Participant, ParticipantStatus;
+export 'src/models/profile.dart' show Language;
 export 'src/models/service_request.dart' show ServiceRequest, ServiceRequestState;
 export 'src/models/session.dart' show Session;
 export 'src/models/track.dart' show Track;

--- a/lib/src/models/credentials.dart
+++ b/lib/src/models/credentials.dart
@@ -1,0 +1,8 @@
+class Credentials {
+  final String provider;
+  final String login;
+  final String password;
+  final bool isNewUser;
+
+  Credentials(this.provider, this.login, this.password, this.isNewUser);
+}

--- a/lib/src/models/profile.dart
+++ b/lib/src/models/profile.dart
@@ -5,3 +5,7 @@ enum Language {
   French,
   Spanish,
 }
+
+extension LanguageExtension on Language {
+  get name => toString().split('.').last;
+}

--- a/lib/src/models/profile.dart
+++ b/lib/src/models/profile.dart
@@ -1,0 +1,7 @@
+// ignore_for_file: constant_identifier_names
+
+enum Language {
+  English,
+  French,
+  Spanish,
+}

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -161,7 +161,7 @@ class PlatformClient {
     String body = jsonEncode({
       'authProvider': credentials.provider,
       'login': credentials.login,
-      'preferredLang': preferredLanguages,
+      'preferredLang': preferredLanguages?.map((language) => language.name),
       'tosAccepted': true,
       'verificationCode': credentials.password,
     });

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -10,6 +10,7 @@ import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:pubnub/pubnub.dart' as pn;
 
+import 'models/credentials.dart';
 import 'models/feedback.dart';
 import 'models/participant.dart';
 import 'models/service_request.dart';
@@ -62,6 +63,22 @@ class PlatformClient {
     await _httpPost('/api/smartapp/verify', body);
   }
 
+  /// Confirms a verification code that was sent to a phone number by [sendPhoneVerificationCode].
+  ///
+  /// [phoneNumber] is the phone number in E.164 format and [verificationCode] is the verification code. If successful,
+  /// the returned [Credentials] can be used to [createAccount] (if [Credentials.isNewUser] is `true`) and to
+  /// [loginWithCredentials].
+  Future<Credentials> confirmPhoneVerificationCode(String phoneNumber, String verificationCode) async {
+    String body = jsonEncode({
+      'authCode': verificationCode,
+      'phoneNumber': phoneNumber,
+    });
+
+    Map<String, dynamic> response = await _httpPost('/api/smartapp/verify/confirm', body);
+
+    return Credentials('PHONE_VERIFICATION', phoneNumber, response['verificationCode'], response['newUser']);
+  }
+
   /// Sends a verification code to an email address.
   ///
   /// [email] is the email address and [recaptchaToken] is the optional reCAPTCHA Enterprise token.
@@ -71,6 +88,22 @@ class PlatformClient {
       'recaptchaToken': recaptchaToken ?? '',
     });
     await _httpPost('/api/smartapp/verify/email', body);
+  }
+
+  /// Confirms a verification code that was sent to an email address by [sendEmailVerificationCode].
+  ///
+  /// [email] is the email address and [verificationCode] is the verification code. If successful,
+  /// the returned [Credentials] can be used to [createAccount] (if [Credentials.isNewUser] is `true`) and to
+  /// [loginWithCredentials].
+  Future<Credentials> confirmEmailVerificationCode(String email, String verificationCode) async {
+    String body = jsonEncode({
+      'authCode': verificationCode,
+      'email': email,
+    });
+
+    Map<String, dynamic> response = await _httpPost('/api/smartapp/verify/email/confirm', body);
+
+    return Credentials('EMAIL_VERIFICATION', email, response['verificationCode'], response['newUser']);
   }
 
   /// Logs in with a token.
@@ -100,60 +133,15 @@ class PlatformClient {
     }
   }
 
-  /// Logs in with a phone number.
-  ///
-  /// [phoneNumber] is the phone number in E.164 format, and [verificationCode] is the verification code sent to the
-  /// phone by [sendPhoneVerificationCode].
-  Future<Session> loginWithPhone(String phoneNumber, String verificationCode) async {
-    // Exchange the phone verification code for a password.
-    var body = jsonEncode({
-      'authCode': verificationCode,
-      'phoneNumber': phoneNumber,
-    });
-    var response = await _httpPost('/api/smartapp/verify/confirm', body);
-    if (response['newUser']) {
-      // TODO: If this is a new user, they need to sign up before logging in.
-      throw PlatformLocalizedException(
-          '', 'The mobile number $phoneNumber is not on file. Please log in with your email or call customer care.');
-    }
-
-    // Login with the phone number and password.
-    body = jsonEncode({
-      'authProvider': 'PHONE_VERIFICATION',
-      'login': phoneNumber,
-      'loginfrom': 'AIRA SMART', // Platform knows the Explorer app as "AIRA SMART".
-      'password': response['verificationCode'],
-    });
-    _session = Session.fromJson(await _httpPost('/api/user/login', body));
-
-    _initSession();
-
-    return _session!;
-  }
-
-  /// Logs in with an email address.
-  ///
-  /// [email] is the email address and [verificationCode] is the verification code sent to the email address by
-  /// [sendEmailVerificationCode].
-  Future<Session> loginWithEmail(String email, String verificationCode) async {
-    // Exchange the email verification code for a password.
+  /// Logs in with [Credentials].
+  Future<Session> loginWithCredentials(Credentials credentials) async {
     String body = jsonEncode({
-      'authCode': verificationCode,
-      'email': email,
-    });
-    Map<String, dynamic> response = await _httpPost('/api/smartapp/verify/email/confirm', body);
-
-    if (response['newUser']) {
-      // TODO: If this is a new user, they need to sign up before logging in.
-    }
-
-    // Login with the email address and password.
-    body = jsonEncode({
-      'authProvider': 'EMAIL_VERIFICATION',
-      'login': email,
+      'authProvider': credentials.provider,
+      'login': credentials.login,
       'loginfrom': 'AIRA SMART', // Platform knows the Explorer app as "AIRA SMART".
-      'password': response['verificationCode'],
+      'password': credentials.password,
     });
+
     _session = Session.fromJson(await _httpPost('/api/user/login', body));
 
     _initSession();
@@ -165,6 +153,20 @@ class PlatformClient {
   Future<void> logout() async {
     // TODO: Actually log out. For now, we're copying the legacy apps and just removing the token.
     _session = null;
+  }
+
+  Future<void> createAccount() async {
+    /*
+                return "/order/guest/basic"
+
+
+            let payload: [String: Any] = [
+            "login": phone,
+            "verificationCode": verificationCode,
+            "referralCode": referralCode ?? ""
+        ]
+
+     */
   }
 
   /// Creates a service request for the logged-in user.

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -161,7 +161,7 @@ class PlatformClient {
     String body = jsonEncode({
       'authProvider': credentials.provider,
       'login': credentials.login,
-      'preferredLang': preferredLanguages?.map((language) => language.name),
+      'preferredLang': preferredLanguages?.map((language) => language.name).toList(growable: false),
       'tosAccepted': true,
       'verificationCode': credentials.password,
     });

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -67,7 +67,7 @@ class PlatformClient {
   /// Confirms a verification code that was sent to a phone number by [sendPhoneVerificationCode].
   ///
   /// [phoneNumber] is the phone number in E.164 format and [verificationCode] is the verification code. If successful,
-  /// the returned [Credentials] can be used to [createAccount] (if [Credentials.isNewUser] is `true`) and to
+  /// the returned [Credentials] can be used to [createAccount] (if [Credentials.isNewUser] is `true`) or to
   /// [loginWithCredentials].
   Future<Credentials> confirmPhoneVerificationCode(String phoneNumber, String verificationCode) async {
     String body = jsonEncode({
@@ -94,7 +94,7 @@ class PlatformClient {
   /// Confirms a verification code that was sent to an email address by [sendEmailVerificationCode].
   ///
   /// [email] is the email address and [verificationCode] is the verification code. If successful,
-  /// the returned [Credentials] can be used to [createAccount] (if [Credentials.isNewUser] is `true`) and to
+  /// the returned [Credentials] can be used to [createAccount] (if [Credentials.isNewUser] is `true`) or to
   /// [loginWithCredentials].
   Future<Credentials> confirmEmailVerificationCode(String email, String verificationCode) async {
     String body = jsonEncode({

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -13,6 +13,7 @@ import 'package:pubnub/pubnub.dart' as pn;
 import 'models/credentials.dart';
 import 'models/feedback.dart';
 import 'models/participant.dart';
+import 'models/profile.dart';
 import 'models/service_request.dart';
 import 'models/session.dart';
 import 'models/track.dart';
@@ -155,18 +156,19 @@ class PlatformClient {
     _session = null;
   }
 
-  Future<void> createAccount() async {
-    /*
-                return "/order/guest/basic"
+  /// Creates an account.
+  Future<Session> createAccount(Credentials credentials, {List<Language>? preferredLanguages}) async {
+    String body = jsonEncode({
+      'authProvider': credentials.provider,
+      'login': credentials.login,
+      'preferredLang': preferredLanguages,
+      'tosAccepted': true,
+      'verificationCode': credentials.password,
+    });
 
+    await _httpPost('/api/order/guest/basic', body);
 
-            let payload: [String: Any] = [
-            "login": phone,
-            "verificationCode": verificationCode,
-            "referralCode": referralCode ?? ""
-        ]
-
-     */
+    return loginWithCredentials(credentials);
   }
 
   /// Creates a service request for the logged-in user.


### PR DESCRIPTION
BREAKING CHANGE: `PlatformClient.loginWithPhone` and `PlatformClient.loginWithEmail` have been removed. Now, once you have a phone or email verification code, you should call  `confirmPhoneVerificationCode` or `confirmEmailVerificationCode` to exchange the verification code for `Credentials`. Then, to create a `Session`, either `loginWithCredentials` (if `Credentials.isNewUser` is `false`) or `createAccount` (if `Credentials.isNewUser` is `true`).