### PR TITLE
feat: client verification codes

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,6 +29,8 @@ void main() {
   ));
 }
 
+enum LoginType { verificationCode, token }
+
 class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
@@ -48,10 +50,12 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
   final TextEditingController _messagingSendKeyController = TextEditingController();
   final TextEditingController _tokenController = TextEditingController();
   final TextEditingController _userIdController = TextEditingController();
+  final TextEditingController _verificationCodeController = TextEditingController();
 
   final RTCVideoRenderer _remoteRenderer = RTCVideoRenderer();
   late final Future<void> _rendererInitialized;
 
+  LoginType _loginType = LoginType.verificationCode;
   MediaStream? _localStream;
   PlatformClient? _platformClient;
   Room? _room;
@@ -66,12 +70,13 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
     super.initState();
 
     // During development, you can set these here instead of through the UI to iterate faster.
-    _apiKeyController.text = '';
+    _apiKeyController.text = 'eA70l1eghObM66Deu3A70BjxYWkbFbwk';
     _clientIdController.text = '';
     _messagingReceiveKeyController.text = '';
     _messagingSendKeyController.text = '';
     _tokenController.text = '';
     _userIdController.text = '';
+    _verificationCodeController.text = '';
 
     _rendererInitialized = _remoteRenderer.initialize();
   }
@@ -89,6 +94,7 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
     _messagingSendKeyController.dispose();
     _tokenController.dispose();
     _userIdController.dispose();
+    _verificationCodeController.dispose();
 
     super.dispose();
   }
@@ -180,6 +186,27 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
       key: _formKey,
       child: Column(
         children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: RadioListTile<LoginType>(
+                  groupValue: _loginType,
+                  onChanged: (LoginType? newValue) => setState(() => _loginType = newValue!),
+                  title: const Text('Login with Verification Code', overflow: TextOverflow.ellipsis),
+                  value: LoginType.verificationCode,
+                ),
+              ),
+              Expanded(
+                child: RadioListTile<LoginType>(
+                  groupValue: _loginType,
+                  onChanged: (LoginType? newValue) => setState(() => _loginType = newValue!),
+                  title: const Text('Login with Token', overflow: TextOverflow.ellipsis),
+                  value: LoginType.token,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
           TextFormField(
             controller: _clientIdController,
             decoration: const InputDecoration(
@@ -212,37 +239,57 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
             },
           ),
           const SizedBox(height: 8),
-          TextFormField(
-            controller: _userIdController,
-            decoration: const InputDecoration(
-              border: OutlineInputBorder(),
-              // Announce validation errors (https://github.com/flutter/flutter/issues/99715).
-              helperText: kIsWeb ? ' ' : null,
-              labelText: 'User ID',
-            ),
-            validator: (String? value) {
-              if (value == null || value.isEmpty) {
-                return 'A user ID is required';
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: 8),
-          TextFormField(
-            controller: _tokenController,
-            decoration: const InputDecoration(
-              border: OutlineInputBorder(),
-              // Announce validation errors (https://github.com/flutter/flutter/issues/99715).
-              helperText: kIsWeb ? ' ' : null,
-              labelText: 'Token',
-            ),
-            validator: (String? value) {
-              if (value == null || value.isEmpty) {
-                return 'A token is required';
-              }
-              return null;
-            },
-          ),
+          ..._loginType == LoginType.verificationCode
+              ? <Widget>[
+                  TextFormField(
+                    controller: _verificationCodeController,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      // Announce validation errors (https://github.com/flutter/flutter/issues/99715).
+                      helperText: kIsWeb ? ' ' : null,
+                      labelText: 'Verification Code',
+                    ),
+                    validator: (String? value) {
+                      if (_loginType == LoginType.verificationCode && (value?.isEmpty ?? true)) {
+                        return 'A verification code is required';
+                      }
+                      return null;
+                    },
+                  ),
+                ]
+              : <Widget>[
+                  TextFormField(
+                    controller: _userIdController,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      // Announce validation errors (https://github.com/flutter/flutter/issues/99715).
+                      helperText: kIsWeb ? ' ' : null,
+                      labelText: 'User ID',
+                    ),
+                    validator: (String? value) {
+                      if (_loginType == LoginType.token && (value?.isEmpty ?? true)) {
+                        return 'A user ID is required';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                  TextFormField(
+                    controller: _tokenController,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      // Announce validation errors (https://github.com/flutter/flutter/issues/99715).
+                      helperText: kIsWeb ? ' ' : null,
+                      labelText: 'Token',
+                    ),
+                    validator: (String? value) {
+                      if (_loginType == LoginType.token && (value?.isEmpty ?? true)) {
+                        return 'A token is required';
+                      }
+                      return null;
+                    },
+                  ),
+                ],
           const SizedBox(height: 8),
           TextFormField(
             controller: _messagingSendKeyController,
@@ -336,7 +383,17 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
       ));
 
       // Log in.
-      await _platformClient!.loginWithToken(_tokenController.text, int.parse(_userIdController.text));
+      if (_loginType == LoginType.verificationCode) {
+        Session session = await _platformClient!.loginWithClientVerificationCode(_verificationCodeController.text);
+        setState(() {
+          // The verification code can only be used once, so switch to logging in with the returned token.
+          _loginType = LoginType.token;
+          _tokenController.text = session.token;
+          _userIdController.text = session.userId.toString();
+        });
+      } else {
+        _platformClient!.loginWithToken(_tokenController.text, int.parse(_userIdController.text));
+      }
 
       // Get the local audio and video. Do this before calling, because if access to the media is blocked, why call?
       _localStream = await navigator.mediaDevices.getUserMedia({'audio': true, 'video': true});

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,7 +70,7 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
     super.initState();
 
     // During development, you can set these here instead of through the UI to iterate faster.
-    _apiKeyController.text = 'eA70l1eghObM66Deu3A70BjxYWkbFbwk';
+    _apiKeyController.text = '';
     _clientIdController.text = '';
     _messagingReceiveKeyController.text = '';
     _messagingSendKeyController.text = '';
@@ -392,7 +392,7 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
           _userIdController.text = session.userId.toString();
         });
       } else {
-        _platformClient!.loginWithToken(_tokenController.text, int.parse(_userIdController.text));
+        await _platformClient!.loginWithToken(_tokenController.text, int.parse(_userIdController.text));
       }
 
       // Get the local audio and video. Do this before calling, because if access to the media is blocked, why call?

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -109,10 +109,11 @@ class PlatformClient {
 
   /// Returns a verification code that can be used to log in the user to the specified client.
   Future<String> createClientVerificationCode(String clientId) async {
-    // This API uses form fields instead of a JSON body.
-    Map<String, String> body = {'clientId': clientId};
-
-    Map<String, dynamic> response = await _httpPost('/api/smartapp/verify/client', body);
+    Map<String, dynamic> response = await _httpPost(
+      '/api/smartapp/verify/client',
+      {'clientId': clientId},
+      additionalHeaders: {'Content-Type': 'application/x-www-form-urlencoded'},
+    );
 
     return response['payload'];
   }
@@ -162,11 +163,12 @@ class PlatformClient {
 
   /// Logs in with a client verification code.
   Future<Session> loginWithClientVerificationCode(String verificationCode) async {
-    // This API uses form fields instead of a JSON body.
-    Map<String, String> body = {'verificationCode': verificationCode};
+    Map<String, dynamic> response = await _httpPost(
+      '/api/smartapp/verify/client/confirm',
+      {'verificationCode': verificationCode},
+      additionalHeaders: {'Content-Type': 'application/x-www-form-urlencoded'},
+    );
 
-    // Exchange the client verification code for phone verification credentials.
-    Map<String, dynamic> response = await _httpPost('/api/smartapp/verify/client/confirm', body);
     Credentials credentials = Credentials(
       'PHONE_VERIFICATION',
       response['verificationCode'],

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -107,6 +107,16 @@ class PlatformClient {
     return Credentials('EMAIL_VERIFICATION', email, response['verificationCode'], response['newUser']);
   }
 
+  /// Returns a verification code that can be used to log in the user to the specified client.
+  Future<String> createClientVerificationCode(String clientId) async {
+    // This API uses form fields instead of a JSON body.
+    Map<String, String> body = {'clientId': clientId};
+
+    Map<String, dynamic> response = await _httpPost('/api/smartapp/verify/client', body);
+
+    return response['payload'];
+  }
+
   /// Logs in with a token.
   ///
   /// Throws a [PlatformInvalidTokenException] if the [token] is invalid.
@@ -148,6 +158,23 @@ class PlatformClient {
     _initSession();
 
     return _session!;
+  }
+
+  /// Logs in with a client verification code.
+  Future<Session> loginWithClientVerificationCode(String verificationCode) async {
+    // This API uses form fields instead of a JSON body.
+    Map<String, String> body = {'verificationCode': verificationCode};
+
+    // Exchange the client verification code for phone verification credentials.
+    Map<String, dynamic> response = await _httpPost('/api/smartapp/verify/client/confirm', body);
+    Credentials credentials = Credentials(
+      'PHONE_VERIFICATION',
+      response['verificationCode'],
+      response['phoneVerificationId'],
+      response['newUser'],
+    );
+
+    return loginWithCredentials(credentials);
   }
 
   /// Logs out the user.

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -172,7 +172,7 @@ class PlatformClient {
     Credentials credentials = Credentials(
       'PHONE_VERIFICATION',
       response['verificationCode'],
-      response['phoneVerificationId'],
+      response['phoneVerificationId'].toString(),
       response['newUser'],
     );
 


### PR DESCRIPTION
This adds support for a simplified login process on devices that can't receive an SMS message or email (e.g. [Envision Glasses](https://www.letsenvision.com/envision-glasses)). It works like this:

1. The Explorer logs in on a device that _can_ receive an SMS message or email.
2. The Explorer requests a verification code for the client ID that will be used by the second device by calling `PlatformClient.createClientVerificationCode`.
3. The client verification code is shared with the second device using a QR code or some other means.
4. The second device logs in with the client verification code by calling `PlatformClient.loginWithClientVerificationCode`.