### PR TITLE
feat!: configurable device ID

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -376,10 +376,10 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
         messagingKeys = PlatformMessagingKeys(_messagingSendKeyController.text, _messagingReceiveKeyController.text);
       }
       _platformClient = PlatformClient(PlatformClientConfig(
-        PlatformEnvironment.dev,
-        _apiKeyController.text,
-        _clientIdController.text,
-        messagingKeys,
+        apiKey: _apiKeyController.text,
+        clientId: _clientIdController.text,
+        environment: PlatformEnvironment.dev,
+        messagingKeys: messagingKeys,
       ));
 
       // Log in.

--- a/test/flutter_aira_test.dart
+++ b/test/flutter_aira_test.dart
@@ -6,7 +6,11 @@ import 'package:http/http.dart';
 import 'package:http/testing.dart';
 
 void main() {
-  final platformClientConfig = PlatformClientConfig(PlatformEnvironment.dev, 'testApiKey', 'testClientId');
+  final platformClientConfig = PlatformClientConfig(
+    apiKey: 'testApiKey',
+    clientId: 'testClientId',
+    environment: PlatformEnvironment.dev,
+  );
 
   group('loginWithToken', () {
     test('should throw PlatformInvalidTokenException on KN-UM-056 error', () async {


### PR DESCRIPTION
BREAKING CHANGE: The `PlatformClientConfig` constructor now uses named parameters instead of positional parameters to make it easier to add configuration options in the future.

The `X-Device-Id` header is used by Platform for fraud prevention and more, so it's important that we have a value for it if possible. This PR allows apps to provide a device ID using the `PlatformClientConfig` in cases where the defaults ([`ANDROID_ID`](https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID) on Android and [`identifierForVendor`](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor) on iOS) are inadequate.