### PR TITLE
feat: add device ID and model to service request context

### DIFF
--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -484,6 +484,8 @@ class PlatformClient {
       };
     } else {
       return {
+        'id': await _deviceId,
+        'model': (await DeviceInfoPlugin().deviceInfo).toMap()['model'],
         'platform': Platform.operatingSystem.toString().split('.').last,
         'platformVersion': Platform.operatingSystemVersion,
       };


### PR DESCRIPTION
This adds the device ID and model to the service request `context` for requests made from iOS and Android.

On my iPhone Xs, the `model` is the generic string "iPhone", which isn't very helpful. However, at this time, we aren't making any decisions based on the specific iPhone model.