### PR TITLE
feat: use QoS level 1 for critical messages

### DIFF
--- a/lib/src/platform_mq.dart
+++ b/lib/src/platform_mq.dart
@@ -50,7 +50,7 @@ class PlatformMQImpl implements PlatformMQ {
       _client.connectionMessage = MqttConnectMessage()
         ..startClean()
         ..withWillMessage(lastWillMessage)
-        ..withWillQos(MqttQos.atMostOnce)
+        ..withWillQos(MqttQos.atLeastOnce)
         ..withWillTopic(lastWillTopic);
     }
 

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -112,7 +112,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
     // Asynchronously subscribe to the room-related topics.
     await _mq.subscribe(_participantEventTopic, MqttQos.atMostOnce, _handleParticipantEventMessage);
     await _mq.subscribe(_participantTopic, MqttQos.atMostOnce, _handleParticipantMessage);
-    await _mq.subscribe(_serviceRequestPresenceTopic, MqttQos.atMostOnce, _handleServiceRequestPresenceMessage);
+    await _mq.subscribe(_serviceRequestPresenceTopic, MqttQos.atLeastOnce, _handleServiceRequestPresenceMessage);
   }
 
   // Factory for creating an initialized room (idea borrowed from https://stackoverflow.com/a/59304510).


### PR DESCRIPTION
This switches from MQTT [Quality of Service](https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/) (QoS) level 0 (at most once) to level 1 (at least once) for critical messages that are safe to deliver multiple times.