### PR TITLE
build(deps): bump device_info_plus from 3.2.2 to 4.0.2

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.4"
+    version: "4.0.2"
   device_info_plus_linux:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: device_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0+1"
+    version: "2.4.0"
   device_info_plus_web:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: device_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.2"
   encrypt:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.1"
   file:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "1.4.3"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -316,7 +316,7 @@ packages:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -372,7 +372,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.1.1"
   pedantic:
     dependency: transitive
     description:
@@ -503,7 +503,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.7.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  device_info_plus: ^3.2.2
+  device_info_plus: ^4.0.2
   flutter:
     sdk: flutter
   flutter_webrtc: ^0.8.11


### PR DESCRIPTION
The previous version was causing compilation errors.
```
./../flutter/.pub-cache/hosted/pub.dartlang.org/device_info_plus_windows-2.1.1/lib/src/device_info_plus_windows.dart:24:35: Error: Required named parameter 'userName' must be provided.
    final data = WindowsDeviceInfo(
                                  ^
../../flutter/.pub-cache/hosted/pub.dartlang.org/device_info_plus_platform_interface-2.4.0/lib/model/windows_device_info.dart:12:3: Context: Found this candidate, but the arguments don't match.
  WindowsDeviceInfo({
  ^^^^^^^^^^^^^^^^^
```