### PR TITLE
feat: add device context to `loginWithCredentials`

### DIFF
--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -153,6 +153,7 @@ class PlatformClient {
   Future<Session> loginWithCredentials(Credentials credentials) async {
     String body = jsonEncode({
       'authProvider': credentials.provider,
+      'device': await _deviceContext,
       'login': credentials.login,
       'loginfrom': 'AIRA SMART', // Platform knows the Explorer app as "AIRA SMART".
       'password': credentials.password,


### PR DESCRIPTION
The device context will be used for fraud detection and to qualify for new-device promotional credit minutes.