### PR TITLE
feat!: simplified mutes

### DIFF
--- a/lib/src/sfu_connection.dart
+++ b/lib/src/sfu_connection.dart
@@ -11,6 +11,16 @@ enum SfuConnectionDirection {
 
 /// Represents a single incoming or outgoing connection to the selective forwarding unit (SFU).
 class SfuConnection {
+  /// Creates a new [SfuConnection].
+  SfuConnection({
+    required this.direction,
+    required this.onConnectionState,
+    required this.onIceCandidate,
+    required this.onSdpOffer,
+    required this.onTrack,
+    required this.trackId,
+  });
+
   final int trackId;
   final SfuConnectionDirection direction;
 
@@ -22,16 +32,6 @@ class SfuConnection {
   final Function(int trackId, RTCIceCandidate candidate) onIceCandidate;
   final Function(int trackId, RTCSessionDescription offer) onSdpOffer;
   final Function(int trackId, RTCTrackEvent event) onTrack;
-
-  /// Creates a new [SfuConnection].
-  SfuConnection({
-    required this.direction,
-    required this.onConnectionState,
-    required this.onIceCandidate,
-    required this.onSdpOffer,
-    required this.onTrack,
-    required this.trackId,
-  });
 
   bool get _isIncoming => direction == SfuConnectionDirection.incoming;
 


### PR DESCRIPTION
Resolves #34.

BREAKING CHANGE: The `Room` now manages its mute states separately from the `MediaStreamTrack`s. Previously, to join a `Room` with the audio muted, you would do this before calling `Room.join`:
```dart
_localMediaStream.getAudioTracks()[0].enabled = false;
``` 

Now, you will do this:
```dart
_room.setAudioMuted(true);
```