### PR TITLE
fix(android): mute and un-mute stop working

### DIFF
--- a/lib/src/sfu_connection.dart
+++ b/lib/src/sfu_connection.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
 /// The direction of the connection to the selective forwarding unit (SFU).
@@ -99,14 +102,22 @@ class SfuConnection {
     if (_isIncoming) {
       throw StateError('Cannot replace audio track on incoming connection');
     }
-    await _audio.sender.replaceTrack(track);
+    if (kIsWeb || !Platform.isAndroid) {
+      await _audio.sender.replaceTrack(track);
+    } else {
+      await _audio.sender.setTrack(track, takeOwnership: false);
+    }
   }
 
   Future<void> replaceVideoTrack(MediaStreamTrack? track) async {
     if (_isIncoming) {
       throw StateError('Cannot replace video track on incoming connection');
     }
-    await _video.sender.replaceTrack(track);
+    if (kIsWeb || !Platform.isAndroid) {
+      await _video.sender.replaceTrack(track);
+    } else {
+      await _video.sender.setTrack(track, takeOwnership: false);
+    }
   }
 
   /// Handles an ICE candidate from the SFU.


### PR DESCRIPTION
On Android, after muting and un-muting the audio or video a couple times, you'll eventually get an error like this:
```
I/flutter ( 3934): 2022-09-08 13:42:34.712846 | SHOUT | Main | an unhandled error occurred
I/flutter ( 3934): Unable to RTCRtpSender::replaceTrack: MediaStreamTrack has been disposed.
I/flutter ( 3934): #0      RTCRtpSenderNative.replaceTrack (package:flutter_webrtc/src/native/rtc_rtp_sender_impl.dart:94:7)
I/flutter ( 3934): <asynchronous suspension>
I/flutter ( 3934): #1      SfuConnection.replaceAudioTrack (package:flutter_aira/src/sfu_connection.dart:102:5)
I/flutter ( 3934): <asynchronous suspension>
I/flutter ( 3934): #2      KurentoRoom._setAudioMuted (package:flutter_aira/src/room.dart:554:7)
I/flutter ( 3934): <asynchronous suspension>
I/flutter ( 3934): #3      KurentoRoom.setAudioMuted (package:flutter_aira/src/room.dart:215:5)
I/flutter ( 3934): <asynchronous suspension>
```

Based on https://stackoverflow.com/q/68826531, it seems like `replaceTrack` will automatically dispose of a replaced track when it thinks it's no longer being used. Using `setTrack` with `takeOwnership: false` seems to address this, but from what I can tell that's an Android-only thing. 🤷🏾 