### PR TITLE
fix: handle non-JSON responses from Platform

### DIFF
--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -555,21 +555,22 @@ class PlatformClient {
       }
     }
 
+    Map<String, dynamic> json;
     try {
-      Map<String, dynamic> json = jsonDecode(body);
-      if (json['response']?['status'] == 'SUCCESS') {
-        return json;
-      } else if (json['response']?['errorCode'] == 'SEC-001') {
-        _session = null;
-        throw const PlatformInvalidTokenException();
-      } else if (json['response']?['errorMessage'] != null) {
-        throw PlatformLocalizedException(json['response']?['errorCode'], json['response']['errorMessage']);
-      } else {
-        throw PlatformUnknownException('Platform returned unexpected body: $body');
-      }
+      json = jsonDecode(body);
     } catch (e) {
-      _log.shout('Unable to parse response to json. Response\'s body: $body', e);
-      rethrow;
+      json = {};
+    }
+
+    if (json['response']?['status'] == 'SUCCESS') {
+      return json;
+    } else if (json['response']?['errorCode'] == 'SEC-001') {
+      _session = null;
+      throw const PlatformInvalidTokenException();
+    } else if (json['response']?['errorMessage'] != null) {
+      throw PlatformLocalizedException(json['response']?['errorCode'], json['response']['errorMessage']);
+    } else {
+      throw PlatformUnknownException('Platform returned unexpected body: $body');
     }
   }
 

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -555,16 +555,21 @@ class PlatformClient {
       }
     }
 
-    Map<String, dynamic> json = jsonDecode(body);
-    if (json['response']?['status'] == 'SUCCESS') {
-      return json;
-    } else if (json['response']?['errorCode'] == 'SEC-001') {
-      _session = null;
-      throw const PlatformInvalidTokenException();
-    } else if (json['response']?['errorMessage'] != null) {
-      throw PlatformLocalizedException(json['response']?['errorCode'], json['response']['errorMessage']);
-    } else {
-      throw PlatformUnknownException('Platform returned unexpected body: $body');
+    try {
+      Map<String, dynamic> json = jsonDecode(body);
+      if (json['response']?['status'] == 'SUCCESS') {
+        return json;
+      } else if (json['response']?['errorCode'] == 'SEC-001') {
+        _session = null;
+        throw const PlatformInvalidTokenException();
+      } else if (json['response']?['errorMessage'] != null) {
+        throw PlatformLocalizedException(json['response']?['errorCode'], json['response']['errorMessage']);
+      } else {
+        throw PlatformUnknownException('Platform returned unexpected body: $body');
+      }
+    } catch (e) {
+      _log.shout('Unable to parse response to json. Response\'s body: $body', e);
+      rethrow;
     }
   }
 


### PR DESCRIPTION
For the second time, I got the surprise to have a request which was returning HTML instead of the json information expected.

This caused the `jsonDecode` to fail parsing the body of the response. The issue here is that we didn't get much information about the body which was causing the issue (only got 'cannot parse <html>'). As it would have been nice to see the content to the body, I've added this here.

Do you think we should allow this to go into prod? My only real reserve here is that it will display what was intended for that Explorer only in Sentry. Is it possible that we could get sensible information in those responses?

Maybe we should do this only when in dev?