### PR TITLE
fix!: no `start` message sent when call is not started with a message or file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### [0.0.32] - 2022-12-19
+### Removed
+- **BREAKING:** `MessagingClient` doesn't have a `sendStart` function anymore (#58)
+
+### [0.0.32] - 2022-12-19
 ### Added
 - Added API for Access Offers (#58)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### [0.0.32] - 2022-12-19
-### Changed
-- `MessagingClient` now automatically handles the `sendStart` message (#61)
-
+### [0.0.33] - 2023-01-19
 ### Removed
-- **BREAKING:** `MessagingClient` doesn't have a `sendStart` function anymore (#61)
+- **BREAKING:** `MessagingClient.sendStart` (#61).
+
+### Fixed
+- No `start` message sent when call is not started with a message or file (#61).
 
 ### [0.0.32] - 2022-12-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### [0.0.32] - 2022-12-19
+### Changed
+- `MessagingClient` now automatically handles the `sendStart` message (#61)
+
 ### Removed
-- **BREAKING:** `MessagingClient` doesn't have a `sendStart` function anymore (#58)
+- **BREAKING:** `MessagingClient` doesn't have a `sendStart` function anymore (#61)
 
 ### [0.0.32] - 2022-12-19
 ### Added

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -180,7 +180,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.31"
+    version: "0.0.33"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -204,7 +204,7 @@ packages:
       name: flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.18"
+    version: "0.9.19"
   form_data:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: mqtt_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.7.3"
+    version: "9.7.4"
   package_info_plus:
     dependency: transitive
     description:
@@ -365,7 +365,7 @@ packages:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.7"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -531,7 +531,7 @@ packages:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+2"
+    version: "0.2.0+3"
   xml:
     dependency: transitive
     description:

--- a/lib/src/messaging_client.dart
+++ b/lib/src/messaging_client.dart
@@ -36,6 +36,7 @@ abstract class MessagingClient {
 
 class MessagingClientPubNub implements MessagingClient {
   MessagingClientPubNub(PlatformMessagingKeys messagingKeys, int userId, String token) : _userId = userId {
+    _log.finest('Initializing PubNub...');
     _pubnub = pn.PubNub(
       defaultKeyset: pn.Keyset(
         // TODO: Setting the `authKey` shouldn't be necessary, but there is a bug in the PubNub SDK where
@@ -105,12 +106,13 @@ content={message: {senderId: 6187, serviceId: 88697, text: with one picture}, fi
       'start': true,
     };
 
+    _log.finest('Sending start message... Content=$content');
     pn.PublishResult result = await _pubnub.publish(_messageChannel, content);
     if (result.isError) {
       throw PlatformUnknownException(result.description);
     }
 
-    _log.finest('Sent start message. Content=$content');
+    _log.finest('Start message sent!');
   }
 
   @override

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -129,8 +129,6 @@ class PlatformClient {
 
       _session = Session(token, userId);
 
-      await _initMessagingClient();
-
       return _session!;
     } on PlatformLocalizedException catch (e) {
       // Platform returns error code KN-UM-056 (NOT_A_USER_TOKEN) if the token is invalid.
@@ -153,8 +151,6 @@ class PlatformClient {
     });
 
     _session = Session.fromJson(await _httpPost('/api/user/login', body));
-
-    await _initMessagingClient();
 
     return _session!;
   }
@@ -262,6 +258,7 @@ class PlatformClient {
 
     messagingClient?.serviceRequestId = serviceRequest.id;
 
+    await _initMessagingClient();
     return KurentoRoom.create(_config.environment, this, _session!, messagingClient, serviceRequest, roomHandler);
   }
 
@@ -899,6 +896,7 @@ class PlatformClient {
 
   Future<void> _initMessagingClient() async {
     if (_config.messagingKeys != null) {
+      await messagingClient?.dispose();
       // Initialize the PubNub client.
       String token = (await _httpPost('/api/pubnub/token', null))['payload'];
       messagingClient = MessagingClientPubNub(_config.messagingKeys!, _userId, token);

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -247,48 +247,6 @@ class PlatformClient {
           }
         },
     };
-    /*
-   {"agentid":0,
-      "hasMessage":false, <<<<<<
-      "access":{
-        "initiatedUserId":null,"serviceRequestId":null,
-        "access":{
-            "entireCall":true,"termsAndConditionsUrl":null,"renewalTimestamp":null,"description":"5-minute calls for short everyday tasks","type":"PRIVATE","enabled":true,"availableToGuests":true,"enforcedOnExplorers":true,"termsAndConditions":null,"effectiveTo":null,"durationUsed":768,"expired":false,"id":38,"class":"promotion","renewalDurationAllowed":null,"key":"FMF_GUEST","tasks":null,"agentMessage":null,"visible":true,"requireAgentApproval":true,"callPeriodLength":86400,"message":"You can now make short calls to Aira agents for free, every day. Great for doing those short tasks around the house. Try it now!","enforcedOnDuration":0,"site":null,"callsPerPeriod":-1,"name":"Free Daily Calls","sticky":false,"activatedEffectiveSeconds":-1,"durationAllowed":-1,"durationPerCall":300,"validationUserProperties":[],"effectiveFrom":null,
-            "account":{
-              "accountId":2579,"allowRecording":true,"accountCode":"","acceptBusinessUsers":null,"createdTimestamp":null,"accountType":null,"name":"Aira Tech Corp","modifiedTimestamp":null,"id":null,"businessType":null
-            },
-            "activated":true
-          },
-          "initiatedUserType":null,"agentVerified":false,"startTime":null,"id":null,"endTime":null,"enabled":true},
-          "requestType":"AIRA", <<<<<<<
-          "transferUsername":null,
-          "latitude":33.08025856393743, <<<<<<
-          "requestSource":"IOSSMART", <<<<<<<<
-          "useWebrtcRoom":true, <<<<<<
-          "message":"", <<<<<<
-          "userid":0,
-          "accountId":null, <<<<<<<
-          "streamType":null,"agentUsername":null,"clientIP":null,
-          "accessOffer":{ <<<<<<
-            "initiatedUserId":null,"serviceRequestId":null,
-            "access":{ <<<<<<<
-              "entireCall":true,"termsAndConditionsUrl":null,"renewalTimestamp":null,"description":"5-minute calls for short everyday tasks","type":"PRIVATE","enabled":true,"availableToGuests":true,"enforcedOnExplorers":true,"termsAndConditions":null,"effectiveTo":null,"durationUsed":768,"expired":false,
-              "id":38, <<<<<<
-              "class":"promotion", <<<<<<
-              "renewalDurationAllowed":null,"key":"FMF_GUEST","tasks":null,"agentMessage":null,"visible":true,"requireAgentApproval":true,"callPeriodLength":86400,"message":"You can now make short calls to Aira agents for free, every day. Great for doing those short tasks around the house. Try it now!","enforcedOnDuration":0,"site":null,"callsPerPeriod":-1,"name":"Free Daily Calls","sticky":false,"activatedEffectiveSeconds":-1,"durationAllowed":-1,"durationPerCall":300,"validationUserProperties":[],"effectiveFrom":null,
-              "account":{
-                "accountId":2579,"allowRecording":true,"accountCode":"","acceptBusinessUsers":null,"createdTimestamp":null,"accountType":null,"name":"Aira Tech Corp","modifiedTimestamp":null,"id":null,"businessType":null
-              },
-              "activated":true
-            },
-            "initiatedUserType":null,"agentVerified":false,"startTime":null,"id":null,"endTime":null,"enabled":true
-          },
-          "context":"{\"permissions\":{\"location\":\"authorizedWhenInUse\"}}",
-          "cannotTalk":false, <<<<<<
-          "action":"REQUEST","serviceid":0,"teamviewer":false,
-          "longitude":-117.29448238390808 <<<<<<
-       }
-     */
 
     if (position != null) {
       params['latitude'] = position.latitude;
@@ -313,7 +271,6 @@ class PlatformClient {
     }
     _log.finest('Sending pre-call message (message: $text, files: ${fileMap?.keys.join(', ')})');
     String? message = text?.trim();
-    await messagingClient!.sendStart();
     if (null != fileMap && fileMap.isNotEmpty) {
       if (fileMap.length == 1) {
         // If we have only one file, send it with the file.

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -6,7 +6,6 @@ import 'package:flutter_aira/src/models/position.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:logging/logging.dart';
 import 'package:mqtt_client/mqtt_client.dart';
-import 'package:pubnub/pubnub.dart' as pn;
 
 import 'messaging_client.dart';
 import 'models/participant.dart';
@@ -124,7 +123,6 @@ class KurentoRoom extends ChangeNotifier implements Room {
   String? _agentName;
   MediaStream? _localStream;
   int? _localTrackId;
-  pn.Subscription? _messageSubscription;
 
   // Private constructor.
   KurentoRoom._(
@@ -338,8 +336,6 @@ class KurentoRoom extends ChangeNotifier implements Room {
   @override
   Future<void> dispose() async {
     _isDisposed = true;
-
-    await _messageSubscription?.dispose();
 
     _mq.dispose();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 0.0.32
+version: 0.0.33
 homepage: https://github.com/aira-collab/flutter_aira
 
 environment:


### PR DESCRIPTION
BREAKING CHANGE: `MessagingClient.sendStart` has been removed and `PlatformClient.messagingClient` is now read-only.