### PR TITLE
build(deps): downgrade `intl` from `0.18.0` to `0.17.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [0.0.35] - 2023-01-24
+### Fixed
+- Downgrade `intl` from `0.18.0` to `0.17.0`, as the former is incompatible with
+  `flutter_localizations`.
+
 ### [0.0.34] - 2023-01-24
 ### Changed
 - Bump dependencies.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -172,7 +172,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.34"
+    version: "0.0.35"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -227,10 +227,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
+    version: "0.17.0"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 0.0.34
+version: 0.0.35
 homepage: https://github.com/aira-collab/flutter_aira
 
 environment:
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_webrtc: ^0.9.19
   http: ^0.13.5
-  intl: ^0.18.0
+  intl: ^0.17.0
   logging: ^1.1.0
   mqtt_client: ^9.7.4
   package_info_plus: ^3.0.2


### PR DESCRIPTION
Resolves this error:
> Because every version of flutter_aira from git depends on intl ^0.18.0 and every version of flutter_localizations from sdk depends on intl 0.17.0, flutter_aira from git is incompatible with flutter_localizations from sdk.