### PR TITLE
feat: debounce reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Debounce reconnects.
 
 ### [0.0.38] - 2023-02-08
 ### Added

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -116,6 +116,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
   bool _isAudioMuted = false;
   bool _isVideoMuted = false;
   bool _isPresentationMuted = false;
+  bool _isReconnecting = false;
   MediaStreamTrack? _presentationVideoTrack;
 
   bool get _isPresenting => null != _presentationVideoTrack;
@@ -606,6 +607,12 @@ class KurentoRoom extends ChangeNotifier implements Room {
   }
 
   Future<void> _reconnect() async {
+    if (_isReconnecting) {
+      _log.warning('a reconnect is already in progress');
+      return;
+    }
+    _isReconnecting = true;
+
     try {
       _log.info('reconnecting');
 
@@ -639,6 +646,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
     } catch (e, s) {
       _log.shout('failed to reconnect', e, s);
     } finally {
+      _isReconnecting = false;
       onReconnected?.call();
     }
   }


### PR DESCRIPTION
While triaging an [error](https://aira-io.sentry.io/share/issue/34fe6fb73a204a1b9507e020201cad69/) in Sentry, I found that two reconnects were in progress simultaneously. Since that's never desired, we now try and limit reconnects to one at a time.