### PR TITLE
fix: `Accept-Language` header not set on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- `Accept-Language` header not set on mobile (#71).
+
 ## [1.0.0] - 2023-02-14
 ### Changed
 - Debounce reconnects (#68).

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -113,7 +113,7 @@ class PlatformClient {
     Map<String, dynamic> response = await _httpPost(
       '/api/smartapp/verify/client',
       {'clientId': clientId},
-      additionalHeaders: {'Content-Type': 'application/x-www-form-urlencoded'},
+      additionalHeaders: {HttpHeaders.contentTypeHeader: 'application/x-www-form-urlencoded'},
     );
 
     return response['payload'];
@@ -168,7 +168,7 @@ class PlatformClient {
     Map<String, dynamic> response = await _httpPost(
       '/api/smartapp/verify/client/confirm',
       {'verificationCode': verificationCode},
-      additionalHeaders: {'Content-Type': 'application/x-www-form-urlencoded'},
+      additionalHeaders: {HttpHeaders.contentTypeHeader: 'application/x-www-form-urlencoded'},
     );
 
     Credentials credentials = Credentials(
@@ -917,11 +917,16 @@ class PlatformClient {
 
   Future<Map<String, String>> _getHeaders(int traceId, {Map<String, String>? additionalHeaders}) async {
     final headers = {
-      'Content-Type': 'application/json',
+      HttpHeaders.contentTypeHeader: 'application/json',
       'X-API-Key': _config.apiKey,
       'X-Client-Id': _config.clientId,
       'X-Trace-Id': traceId.toString(),
     };
+
+    if (!kIsWeb) {
+      // The http package does not automatically set the Accept-Language header on mobile.
+      headers[HttpHeaders.acceptLanguageHeader] = Platform.localeName.replaceAll('_', '-');
+    }
 
     if (_session != null) {
       headers['X-Aira-Token'] = _token;


### PR DESCRIPTION
Platform uses the `Accept-Language` header to localize error messages, but the `http` package does not appear to automatically set it on mobile. 