### PR TITLE
fix(PubNub): fixed pubnub reconnection issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2023-03-31
+### Added
+- automatic PubNub reconnection when data connection fails or changes (#74).
+
 ## [1.1.0] - 2023-03-24
 ### Added
-- automatic reconnection when data connection fails or changes (#73).
+- automatic WebRTC reconnection when data connection fails or changes (#73).
 
 ## [1.0.2] - 2023-03-07
 ### Fixed

--- a/lib/src/messaging_client.dart
+++ b/lib/src/messaging_client.dart
@@ -4,6 +4,7 @@ import 'package:flutter_aira/src/models/sent_file_info.dart';
 import 'package:flutter_aira/src/platform_client.dart';
 import 'package:flutter_aira/src/platform_exceptions.dart';
 import 'package:logging/logging.dart';
+import 'package:pubnub/networking.dart';
 import 'package:pubnub/pubnub.dart' as pn;
 
 import 'models/message.dart';
@@ -50,6 +51,9 @@ class MessagingClientPubNub implements MessagingClient {
         subscribeKey: messagingKeys.receiveKey,
         userId: pn.UserId(userId.toString()),
       ),
+      networking: NetworkingModule(
+        retryPolicy: pn.RetryPolicy.exponential(maxRetries: 10),
+      )
     );
     _pubnub.setToken(token);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/aira-collab/flutter_aira
 
 environment:


### PR DESCRIPTION
Once we have a disconnection due to network glitch or network change, PubNub wasn't attempting to reconnect. This PR fixes this.

> Based on https://www.pubnub.com/docs/sdks/dart/api-reference/publish-and-subscribe#description-2, it sounds like if the PubNub client gets disconnected from a channel for whatever reason, it won’t automatically reconnect. If we want it to do that, we need to specify a RetryPolicy when creating the client, similar to https://github.com/pubnub/dart/issues/19#issuecomment-692153308.