### PR TITLE
fix(reconnect): reestablishment of presentation video track when a reconnect happens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2023-07-03
+### Fixed
+- Reconnection now reestablishes presentation if a presentation was ongoing (#83)
+
 ## [1.4.0] - 2023-06-15
 ### New
 - added `Position.toJson` and `Position.fromJson` (#82)

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -5,16 +5,16 @@ PODS:
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - flutter_webrtc (0.9.20):
+  - flutter_webrtc (0.9.31):
     - Flutter
-    - WebRTC-SDK (= 104.5112.09)
+    - WebRTC-SDK (= 104.5112.17)
   - package_info_plus (0.4.5):
     - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
   - ReachabilitySwift (5.0.0)
-  - WebRTC-SDK (104.5112.09)
+  - WebRTC-SDK (104.5112.17)
 
 DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
@@ -22,7 +22,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_webrtc (from `.symlinks/plugins/flutter_webrtc/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -41,18 +41,18 @@ EXTERNAL SOURCES:
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/ios"
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
 
 SPEC CHECKSUMS:
   connectivity_plus: 413a8857dd5d9f1c399a39130850d02fe0feaf7e
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  flutter_webrtc: 15c5fb4ea324f3178ff97c0f02b9467b85977e42
+  flutter_webrtc: 02c023207f972145a3bc8c7aada86754f264d563
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
-  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
+  path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  WebRTC-SDK: 3fa5c6fa717314fade68bffed85737484a28ad0b
+  WebRTC-SDK: 082ae4893212534a779ca233f19a9df8efd5f3bd
 
 PODFILE CHECKSUM: f4c3d0c50d5147ed2595bb596964ef7f31b8e428
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,7 +204,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.4.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -128,9 +128,9 @@ class KurentoRoom extends ChangeNotifier implements Room {
   bool _isVideoMuted = false;
   bool _isPresentationMuted = false;
   bool _isReconnecting = false;
-  MediaStreamTrack? _presentationVideoTrack;
+  MediaStream? _presentationStream;
 
-  bool get _isPresenting => null != _presentationVideoTrack;
+  bool get _isPresenting => null != _presentationStream;
   ServiceRequestState _serviceRequestState = ServiceRequestState.queued;
   String? _agentName;
   MediaStream? _localStream;
@@ -308,10 +308,14 @@ class KurentoRoom extends ChangeNotifier implements Room {
     }
     // Eventually, we will create a separate connection for screen sharing. That requires changes to Platform and Dash,
     // so for now, we start presenting by replacing the Explorer's video track with the display video track.
-    _presentationVideoTrack = displayStream.getVideoTracks()[0];
-    await _connectionByTrackId[_localTrackId]!.replaceVideoTrack(_isPresentationMuted ? null : _presentationVideoTrack);
+    _presentationStream = await displayStream.clone();
+    if ((_localStream?.getAudioTracks().isNotEmpty ?? false) && _presentationStream!.getAudioTracks().isEmpty) {
+      await _presentationStream?.addTrack(_localStream!.getAudioTracks()[0]);
+    }
+    MediaStreamTrack presentationTrack = displayStream.getVideoTracks()[0];
+    await _connectionByTrackId[_localTrackId]!.replaceVideoTrack(_isPresentationMuted ? null : presentationTrack);
     await _updateParticipantStatus();
-    _log.info('started presenting track=${_presentationVideoTrack!.label}');
+    _log.info('started presenting track=${presentationTrack.label}');
   }
 
   @override
@@ -323,7 +327,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
     // track.
     await _connectionByTrackId[_localTrackId]!
         .replaceVideoTrack(_isVideoMuted || !_hasVideoTrack ? null : _localStream!.getVideoTracks()[0]);
-    _presentationVideoTrack = null;
+    _presentationStream = null;
     await _updateParticipantStatus();
     _log.info('stopped presenting');
   }
@@ -697,7 +701,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
       if (muted) {
         await _connectionByTrackId[_localTrackId]!.replaceVideoTrack(null);
       } else {
-        await _connectionByTrackId[_localTrackId]!.replaceVideoTrack(_presentationVideoTrack);
+        await _connectionByTrackId[_localTrackId]!.replaceVideoTrack(_presentationStream!.getVideoTracks()[0]);
       }
     }
   }
@@ -709,7 +713,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
 
     _localTrackId = track.id;
 
-    await _connectTrack(_localTrackId!, _localStream);
+    await _connectTrack(_localTrackId!, _isPresenting ? _presentationStream : _localStream);
   }
 
   /// Creates and connects a track to receive a remote stream from Kurento.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/aira-collab/flutter_aira
 
 environment:

--- a/test/flutter_aira_test.dart
+++ b/test/flutter_aira_test.dart
@@ -70,4 +70,47 @@ void main() {
       expect(1234, userLogin.userId);
     });
   });
+
+  group('Position', () {
+    // 36.00282558105645, -78.93345583177252
+    // 36.00404070162735, -78.93306959369106
+    //
+    // according to Google, this is 474.08 ft or 144.4996 meters from each other, but we get 139.5 meters...
+    // is this close enough for now? Yes!
+    test('Calculated Distance', () {
+      var now = DateTime.now();
+      var p1 = Position(latitude: 36.00282558105645, longitude: -78.93345583177252, timestamp: now.subtract(const Duration(seconds: 10)));
+      var p2 = Position(latitude: 36.00404070162735, longitude: -78.93306959369106, timestamp: now);
+      var distanceFrom = p1.distanceFrom(p2);
+      expect(distanceFrom, lessThan(139.6));
+      expect(distanceFrom, greaterThan(139.5));
+    });
+    // This test was added to confirm that the distance delta we get with Google is not an implementation issue.
+    test('Calculated Distance according to https://stackoverflow.com/questions/365826/calculate-distance-between-2-gps-coordinates', () {
+      var now = DateTime.now();
+      var p1 = Position(latitude: 51.5, longitude: 0, timestamp: now.subtract(const Duration(seconds: 10)));
+      var p2 = Position(latitude: 38.8, longitude: -77.1, timestamp: now);
+      var distanceFrom = p1.distanceFrom(p2);
+      expect(distanceFrom, lessThan(5918185.1));
+      expect(distanceFrom, greaterThan(5918185.0));
+    });
+    // 139.5 meters in 30 seconds >>> 4.65m/s
+    test('Calculated Speed', () {
+      var now = DateTime.now();
+      var p1 = Position(latitude: 36.00282558105645, longitude: -78.93345583177252, timestamp: now.subtract(const Duration(seconds: 30)));
+      var p2 = Position(latitude: 36.00404070162735, longitude: -78.93306959369106, timestamp: now);
+      var speed1 = p1.speedFrom(p2);
+      var speed2 = p2.speedFrom(p1);
+      expect(speed1, greaterThan(4));
+      expect(speed1, lessThan(5));
+      expect(speed1, equals(speed2));
+    });
+    test('Same timestamp could cause a division by zero', () {
+      var now = DateTime.now();
+      var p1 = Position(latitude: 36.00282558105645, longitude: -78.93345583177252, timestamp: now);
+      var p2 = Position(latitude: 36.00404070162735, longitude: -78.93306959369106, timestamp: now);
+      var speed = p1.speedFrom(p2);
+      expect(speed, equals(-1));
+    });
+  });
 }


### PR DESCRIPTION
When `Room._reconnect` was called during a presentation, the presentation stream wasn't reestablished. This is now reestablished if we were presenting.