### PR TITLE
fix(platform_client & room): use of a common location throttling mechanism to avoid concurrent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2023-07-17
+### Fixed
+- Unified Location Update Throttling to prevent concurrent location update through different routes (#85)
+
+### Changed
+- Updated analysis rules (#84)
+
 ## [1.4.1] - 2023-07-03
 ### Fixed
 - Reconnection now reestablishes presentation if a presentation was ongoing (#83)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: ab96a1cb3beeccf8145c52e449233fe68364c9641623acd3adad66f8184f1039
+      sha256: b74e3842a52c61f8819a1ec8444b4de5419b41a7465e69d4aa681445377398b0
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   async:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: dart_webrtc
-      sha256: "8949301071ac7c3fb8f78ef7dffc48652db16f2ec63d84078b608f2ca27cca38"
+      sha256: "3f581ea799829fabd6e0b99bd2210146e4d107c7b3ac8495af3510737a5c5c1a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.17"
+    version: "1.1.1"
   dbus:
     dependency: transitive
     description:
@@ -204,15 +204,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.1"
+    version: "1.4.2"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -227,10 +227,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_webrtc
-      sha256: "4a3194900981ac7a2aa1e68a37903d8910cc3459c7a1ab68ad0407310cea1642"
+      sha256: f7e3ee080638db1793109a2ca4f1391413907057cbee46a7f9bd1dc2a636d1cd
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.34"
+    version: "0.9.36"
   form_data:
     dependency: transitive
     description:
@@ -371,10 +371,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "1995d88ec2948dac43edf8fe58eb434d35d22a2940ecee1a9fefcd62beee6eb3"
+      sha256: "916731ccbdce44d545414dd9961f26ba5fbaa74bcbb55237d8e65a623a8c7297"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   path_provider_linux:
     dependency: transitive
     description:
@@ -455,14 +455,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  process:
-    dependency: transitive
-    description:
-      name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
@@ -552,10 +544,10 @@ packages:
     dependency: transitive
     description:
       name: webrtc_interface
-      sha256: "0ac4693f921c81005edefd2f43b9fe84b0ed54481474fe1ee16b789b0c84a77c"
+      sha256: "0dd96f4d7fb6ba9895930644cebd3f1adb5179caa83cb1760061b2fe9cba5aad"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.13"
+    version: "1.1.0"
   win32:
     dependency: transitive
     description:
@@ -568,10 +560,10 @@ packages:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: ee1505df1426458f7f60aac270645098d318a8b4766d85fde75f76f2e21807d1
+      sha256: e0b1147eec179d3911f1f19b59206448f78195ca1d20514134e10641b7d7fbff
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   xml:
     dependency: transitive
     description:
@@ -581,5 +573,5 @@ packages:
     source: hosted
     version: "6.3.0"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">3.0.0 <4.0.0"
   flutter: ">=3.3.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,8 +36,8 @@ dependencies:
 
   flutter_aira:
     path: ../
-  flutter_webrtc: ^0.9.6
-  logging: ^1.0.2
+  flutter_webrtc: ^0.9.36
+  logging: ^1.2.0
 
 dev_dependencies:
   flutter_test:
@@ -48,7 +48,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.1
+  flutter_lints: ^2.0.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -6,6 +6,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_aira/flutter_aira.dart';
 import 'package:flutter_aira/src/models/convertion_extension.dart';
+import 'package:flutter_aira/src/platform_client.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:logging/logging.dart';
 import 'package:mqtt_client/mqtt_client.dart';
@@ -109,6 +110,17 @@ abstract class Room implements Listenable {
 }
 
 class KurentoRoom extends ChangeNotifier implements Room {
+
+  // Private constructor.
+  KurentoRoom._(
+      this._env,
+      this._client,
+      Session session,
+      this.messagingClient,
+      this._serviceRequest,
+      this._roomHandler,
+      );
+
   final Logger _log = Logger('KurentoRoom');
 
   final PlatformEnvironment _env;
@@ -121,7 +133,6 @@ class KurentoRoom extends ChangeNotifier implements Room {
 
   final Map<int, SfuConnection> _connectionByTrackId = {};
   final Map<int, int> _incomingTrackIdByOutgoingTrackId = {};
-  DateTime _lastLocationUpdate = DateTime.fromMillisecondsSinceEpoch(0);
 
   bool _isDisposed = false;
   bool _isAudioMuted = false;
@@ -139,15 +150,19 @@ class KurentoRoom extends ChangeNotifier implements Room {
   StreamSubscription<ConnectivityResult>? _connectivityMonitoringSubscription;
   ConnectivityResult? _currentlyUsedConnectionType;
 
-  // Private constructor.
-  KurentoRoom._(
-    this._env,
-    this._client,
-    Session session,
-    this.messagingClient,
-    this._serviceRequest,
-    this._roomHandler,
-  );
+  // Factory for creating an initialized room (idea borrowed from https://stackoverflow.com/a/59304510).
+  static Future<Room> create(PlatformEnvironment env, PlatformClient client, Session session,
+      MessagingClient? messagingClient, ServiceRequest serviceRequest, RoomHandler roomHandler) async {
+    KurentoRoom room = KurentoRoom._(env, client, session, messagingClient, serviceRequest, roomHandler);
+    try {
+      await room._init(session);
+      return room;
+    } catch (e) {
+      // If something went wrong, trash the room.
+      await room.dispose();
+      rethrow;
+    }
+  }
 
   Future<void> _init(Session session) async {
     _mq = await PlatformMQImpl.create(_env, session, lastWillMessage: _lastWillMessage, lastWillTopic: _lastWillTopic);
@@ -186,20 +201,6 @@ class KurentoRoom extends ChangeNotifier implements Room {
       }
 
       _currentlyUsedConnectionType = result;
-    }
-  }
-
-  // Factory for creating an initialized room (idea borrowed from https://stackoverflow.com/a/59304510).
-  static Future<Room> create(PlatformEnvironment env, PlatformClient client, Session session,
-      MessagingClient? messagingClient, ServiceRequest serviceRequest, RoomHandler roomHandler) async {
-    KurentoRoom room = KurentoRoom._(env, client, session, messagingClient, serviceRequest, roomHandler);
-    try {
-      await room._init(session);
-      return room;
-    } catch (e) {
-      // If something went wrong, trash the room.
-      await room.dispose();
-      rethrow;
     }
   }
 
@@ -363,12 +364,10 @@ class KurentoRoom extends ChangeNotifier implements Room {
       return;
     }
 
-    DateTime now = DateTime.now();
-    if (now.difference(_lastLocationUpdate).inSeconds < 1) {
+    if (_client.shouldThrottlePositionUpdate) {
       // Same throttling delay as `PlatformClient.inquireForGPSActivatedOffer`.
       return;
     }
-    _lastLocationUpdate = now;
 
     List<Map<String, dynamic>> serviceInfoData = [
       {'instrumentationType': 'TYPE_GPS', 'paramName': 'LAT', 'paramValue': position.latitude},
@@ -393,7 +392,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
         _mq.publish(_serviceInfoTopic, MqttQos.atMostOnce, jsonEncode({'data': serviceInfoData})),
         _mq.publish(_gpsLocationTopic, MqttQos.atMostOnce, jsonEncode(gpsLocationData)),
       ]);
-      _log.finest('Published location info\n\t$serviceInfoData\n\t$gpsLocationData\n\tat ${_lastLocationUpdate.millisecondsSinceEpoch}');
+      _log.finest('Published location info\n\t$serviceInfoData\n\t$gpsLocationData\n\tat ${_client.lastLocationUpdateTimestamp.millisecondsSinceEpoch}');
     } catch (e) {
       _log.warning('Unable to send data to topic $_serviceInfoTopic & $_gpsLocationTopic', e);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 1.4.1
+version: 1.4.2
 homepage: https://github.com/aira-collab/flutter_aira
 
 environment:
   flutter: ">=3.0.0"
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">3.0.0"
 
 dependencies:
   android_id: ^0.1.3+1
@@ -14,17 +14,17 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_webrtc: ^0.9.19
+  flutter_webrtc: ^0.9.36
   http: ^0.13.5
   intl: any
-  logging: ^1.1.0
+  logging: ^1.2.0
   meta: ^1.8.0
   mqtt_client: ^9.8.0
   package_info_plus: ^3.0.2
   pubnub: ^4.2.2
 
 dev_dependencies:
-  flutter_lints: ^2.0.1
+  flutter_lints: ^2.0.2
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
We have two APIs to update Explorer's locations: 

1. `Room.updateLocation` which uses a rabbitMQ API to communicate the update. This function is used to update location during a call.
2. `PlatformClient.inquireForGPSActivatedOffer` which uses a REST endpoint to know if there is a new GPS activated offer at a specific location. This function is used before calls and in the background.

These CPU intensive calls execute the same code on the backend which can cause a "endpoint modified concurrently" PlatformLocalizedException if a user ends up to execute this code while his previous call is not finished.

This PR fixes this issue by using a common throttling mechanism between these two functions and by increasing the delay between the possible calls from 1 second to 1.5 seconds.