### PR TITLE
fix(room): fixed the source of the video pixelation when starting or stoping a presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2023-07-27
+### Fixed
+- `Room.startPresenting` and `Room.stopPresenting` are now re-creating the outgoing track for mobile to avoid the video pixelation issue (#87)
+
 ## [1.5.0] - 2023-07-20
 ### Changed
 - **BREAKING:** `Rating` enum now has a "Excellent" element (#86)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: b74e3842a52c61f8819a1ec8444b4de5419b41a7465e69d4aa681445377398b0
+      sha256: "21afe4333076c02877d14f4a89df111e658a6d466cbfc802eb705eb91bd5adfd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.0"
   async:
     dependency: transitive
     description:
@@ -204,7 +204,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.0"
+    version: "1.5.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -435,10 +435,10 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      sha256: "43798d895c929056255600343db8f049921cbec94d31ec87f1dc5c16c01935dd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   pointycastle:
     dependency: transitive
     description:
@@ -467,10 +467,10 @@ packages:
     dependency: transitive
     description:
       name: pubnub
-      sha256: "95684a0297697878fc634f96ae37ea514206eca63ffa06a188da0d8aae6430e6"
+      sha256: "8de9f31f24d86b54635e19217698588f45e1cd9de75a8b65e72c8d08686eaaf6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/sfu_connection.dart
+++ b/lib/src/sfu_connection.dart
@@ -51,8 +51,7 @@ class SfuConnection {
     // Create the peer connection.
     _peerConnection = await createPeerConnection(configuration)
       ..onConnectionState = ((state) => onConnectionState.call(trackId, state))
-      ..onIceCandidate =
-          ((candidate) => onIceCandidate.call(trackId, candidate))
+      ..onIceCandidate = ((candidate) => onIceCandidate.call(trackId, candidate))
       ..onTrack = ((event) => onTrack.call(trackId, event));
 
     if (_isIncoming) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 1.5.0
+version: 1.5.1
 homepage: https://github.com/aira-collab/flutter_aira
 
 environment:
@@ -21,7 +21,7 @@ dependencies:
   meta: ^1.8.0
   mqtt_client: ^9.8.0
   package_info_plus: ^3.0.2
-  pubnub: ^4.2.2
+  pubnub: ^4.2.4
 
 dev_dependencies:
   flutter_lints: ^2.0.2


### PR DESCRIPTION
As reported in some of the following links:
https://airasproductt-hqa4190.slack.com/archives/C044B4WAK1U/p1689980551973879?thread_ts=1689976009.201869&cid=C044B4WAK1U
https://airasproductt-hqa4190.slack.com/archives/C044B4WAK1U/p1690404970446239
https://airasproductt-hqa4190.slack.com/archives/C044B4WAK1U/p1690417428049009

The problem:
Starting or stoping a presentation could cause a pixelation of the video on the Agent side. 

Observations:
After some experimentation, I discovered that, once I succeed to start a presentation which was causing the pixelation, the video dimensions failed to change although it should have. This "resolution" change seems to be at the source of the problem.
We also noted that a reconnect always seems to fix the issue.

The fix:
After attempting to address the "resolution" problem without success, I decided to change the way we start and end presentations for a track re-creation (which is the equivalent to a partial reconnect). 

Side effects:
The process to start and stop a presentation is longer and causes the Agent to lose the audio and video for about 2 seconds.
There is no longer any kind of pixelation.