### PR TITLE
feat: add `PlatformBusinessLoginRequiredException`

### DIFF
--- a/lib/flutter_aira.dart
+++ b/lib/flutter_aira.dart
@@ -6,18 +6,22 @@ export 'src/models/call_history.dart' show CallSession, SessionFeedback;
 export 'src/models/credentials.dart' show Credentials;
 export 'src/models/feedback.dart' show AgentFeedback, Feedback, Rating;
 export 'src/models/message.dart' show Message;
+export 'src/models/minute_sharing.dart' show MinuteSharingMember, MinuteSharingInformation;
 export 'src/models/paged.dart' show Paged;
 export 'src/models/participant.dart' show Participant, ParticipantStatus;
 export 'src/models/photo.dart' show Photo;
 export 'src/models/position.dart' show Position;
 export 'src/models/profile.dart' show Language, Profile, ProfileType;
-export 'src/models/minute_sharing.dart' show MinuteSharingMember, MinuteSharingInformation;
 export 'src/models/service_request.dart' show ServiceRequest, ServiceRequestState;
 export 'src/models/session.dart' show Session;
 export 'src/models/track.dart' show Track;
-export 'src/models/user.dart' show User;
 export 'src/models/usage.dart' show Usage, PlanUsageBreakdown;
+export 'src/models/user.dart' show User;
 export 'src/platform_client.dart' show PlatformClient, PlatformClientConfig, PlatformEnvironment, PlatformMessagingKeys;
 export 'src/platform_exceptions.dart'
-    show PlatformLocalizedException, PlatformInvalidTokenException, PlatformUnknownException;
+    show
+        PlatformBusinessLoginRequiredException,
+        PlatformLocalizedException,
+        PlatformInvalidTokenException,
+        PlatformUnknownException;
 export 'src/room.dart' show Room, RoomHandler;

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -1267,7 +1267,7 @@ class PlatformClient {
       throw PlatformBusinessLoginRequiredException(
         json['response']['errorCode'],
         json['response']['errorMessage'],
-        json['metadata']?['connection'],
+        json['metadata']['connection'],
       );
     } else if (json['response']?['errorMessage'] != null) {
       throw PlatformLocalizedException(

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -1287,6 +1287,12 @@ class PlatformClient {
     } else if (json['response']?['errorCode'] == 'SEC-001') {
       _session = null;
       throw const PlatformInvalidTokenException();
+    } else if (json['response']?['errorCode'] == 'AIRA-ACCESS-017' && json['metadata']?['connection'] != null) {
+      throw PlatformBusinessLoginRequiredException(
+        json['response']['errorCode'],
+        json['response']['errorMessage'],
+        json['metadata']?['connection'],
+      );
     } else if (json['response']?['errorMessage'] != null) {
       throw PlatformLocalizedException(
         json['response']?['errorCode'],

--- a/lib/src/platform_exceptions.dart
+++ b/lib/src/platform_exceptions.dart
@@ -19,6 +19,20 @@ class PlatformInvalidTokenException implements Exception {
   String toString() => 'PlatformInvalidTokenException';
 }
 
+/// Exception thrown when the operation requires the user to log in with their business credentials.
+class PlatformBusinessLoginRequiredException extends PlatformLocalizedException {
+  final String _connection;
+
+  const PlatformBusinessLoginRequiredException(
+    String code,
+    String message,
+    this._connection,
+  ) : super(code, message);
+
+  /// The name of the required Auth0 enterprise connection.
+  String get connection => _connection;
+}
+
 /// Exception thrown when something went wrong but we don't have a localized error message from Platform (e.g. Platform
 /// was unreachable).
 class PlatformUnknownException implements Exception {


### PR DESCRIPTION
This exception is thrown by Platform when an operation requires the user to log in with their business credentials. The name of the required Auth0 enterprise connection is available in the `connection` property.