### PR TITLE
feat: new Exception to indicate account deletion failure reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2023-10-16
+### New
+- `PlatformDeleteAccountException` is now a possible exception thrown by `platformClient.deleteAccount` to indicate the user deleting his account has a plan subscription which should be resolved before deleting his account. (#96)
+
 ## [1.7.0] - 2023-09-27
 ### New
 - `PlatformClient.updateTermsOfServiceAccepted(bool)` to update the Terms of Service status (#91)

--- a/lib/flutter_aira.dart
+++ b/lib/flutter_aira.dart
@@ -20,8 +20,9 @@ export 'src/models/user.dart' show User;
 export 'src/platform_client.dart' show PlatformClient, PlatformClientConfig, PlatformEnvironment, PlatformMessagingKeys;
 export 'src/platform_exceptions.dart'
     show
+        PlatformDeleteAccountException,
         PlatformBusinessLoginRequiredException,
-        PlatformLocalizedException,
         PlatformInvalidTokenException,
+        PlatformLocalizedException,
         PlatformUnknownException;
 export 'src/room.dart' show Room, RoomHandler;

--- a/lib/src/platform_exceptions.dart
+++ b/lib/src/platform_exceptions.dart
@@ -20,8 +20,8 @@ class PlatformInvalidTokenException implements Exception {
 }
 
 /// Exception thrown when an Explorer tries to delete his account before cancelling his subscription.
-/// For more details, see: https://github.com/aira/platform/blob/29eba575a495e06a0364b7904cbbb52adee81ea0/core/server/AiraPlatform/src/main/java/io/aira/action/delete/user/UserDeleteRestController.java#L77
 class PlatformDeleteAccountException extends PlatformLocalizedException {
+  // For more details, see: https://github.com/aira/platform/blob/29eba575a495e06a0364b7904cbbb52adee81ea0/core/server/AiraPlatform/src/main/java/io/aira/action/delete/user/UserDeleteRestController.java#L77
   const PlatformDeleteAccountException(String code, String message) : super(code, message);
 }
 

--- a/lib/src/platform_exceptions.dart
+++ b/lib/src/platform_exceptions.dart
@@ -19,6 +19,12 @@ class PlatformInvalidTokenException implements Exception {
   String toString() => 'PlatformInvalidTokenException';
 }
 
+/// Exception thrown when an Explorer tries to delete his account before cancelling his subscription.
+/// For more details, see: https://github.com/aira/platform/blob/29eba575a495e06a0364b7904cbbb52adee81ea0/core/server/AiraPlatform/src/main/java/io/aira/action/delete/user/UserDeleteRestController.java#L77
+class PlatformDeleteAccountException extends PlatformLocalizedException {
+  const PlatformDeleteAccountException(String code, String message) : super(code, message);
+}
+
 /// Exception thrown when the operation requires the user to log in with their business credentials.
 class PlatformBusinessLoginRequiredException extends PlatformLocalizedException {
   final String _connection;

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -124,7 +124,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
     this._roomHandler,
   );
 
-  final Logger _log = Logger('KurentoRoom');
+  static final Logger _log = Logger('KurentoRoom');
 
   final PlatformEnvironment _env;
   final PlatformClient _client;
@@ -167,6 +167,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
       await room._init(session);
       return room;
     } catch (e) {
+      _log.shout('Unable to initialize the WebRTC Room.', e);
       // If something went wrong, trash the room.
       await room.dispose();
       rethrow;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 1.7.0
+version: 1.8.0
 homepage: https://github.com/aira-collab/flutter_aira
 
 environment:


### PR DESCRIPTION
`PlatformClient.deleteAccount` is now capable to throw `PlatformDeleteAccountException` to indicate the failure reason.