### PR TITLE
fix(location): Increased the throttling duration to 2 seconds for location updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2023-11-06
+### Changed
+- Increased the throttling duration to 2 seconds for location updates (#92)
+
 ## [1.7.0] - 2023-09-27
 ### New
 - `PlatformClient.updateTermsOfServiceAccepted(bool)` to update the Terms of Service status (#91)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,7 +204,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.7.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -227,10 +227,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_webrtc
-      sha256: da6fb0f0f9515b2c64608011e3ad314e6a858bbf1c57477f418621996e7d22d2
+      sha256: "8522e9f347aed9f03ec591d05fc286a698c1b11a1a6d3e994e92727d24c6f352"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.45"
+    version: "0.9.46"
   form_data:
     dependency: transitive
     description:
@@ -363,10 +363,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "6b8b19bd80da4f11ce91b2d1fb931f3006911477cec227cce23d3253d80df3f1"
+      sha256: e595b98692943b4881b219f0a9e3945118d3c16bd7e2813f98ec6e532d905f72
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -419,10 +419,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
+      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
   platform_detect:
     dependency: transitive
     description:
@@ -467,10 +467,10 @@ packages:
     dependency: transitive
     description:
       name: pubnub
-      sha256: "8de9f31f24d86b54635e19217698588f45e1cd9de75a8b65e72c8d08686eaaf6"
+      sha256: b00c62c6a87d66497202c34c7b5621ababbb55ad7ad4f9016762d653330794c6
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "4.3.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_aira/flutter_aira.dart';
 import 'package:flutter_aira/src/messaging_client.dart';
 import 'package:flutter_aira/src/models/sent_file_info.dart';
+import 'package:flutter_aira/src/throttler.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
@@ -44,7 +45,7 @@ class PlatformClient {
 
   MessagingClient? get messagingClient => _messagingClient;
 
-  DateTime _lastLocationUpdateTimestamp = DateTime.fromMillisecondsSinceEpoch(0);
+  final Throttler _lastLocationUpdateThrottler = Throttler(delay: 2000); // every 2 seconds
   AccessOfferDetails? _lastAccessOfferUpdate;
 
   /// Discards any resources associated with the [PlatformClient].
@@ -1330,15 +1331,7 @@ class PlatformMessagingKeys {
 }
 
 /// This extension is a way for us to expose and share location update timestamp functionality internally only.
-extension LocationThrottling on PlatformClient {
-  DateTime get lastLocationUpdateTimestamp => _lastLocationUpdateTimestamp;
-  bool get shouldThrottlePositionUpdate {
-    DateTime now = DateTime.now();
-    if (now.difference(_lastLocationUpdateTimestamp).inMilliseconds < 1500) {
-      // Same throttling delay as `KurrentoRoom.updateLocation`.
-      return true;
-    }
-    _lastLocationUpdateTimestamp = now;
-    return false;
-  }
+extension SDKPrivatePlatformClient on PlatformClient {
+  DateTime get lastLocationUpdateTimestamp => _lastLocationUpdateThrottler.lastTimestamp;
+  bool get shouldThrottlePositionUpdate => _lastLocationUpdateThrottler.shouldThrottle;
 }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -671,6 +671,11 @@ class KurentoRoom extends ChangeNotifier implements Room {
   }
 
   void _handleConnectionState(int trackId, RTCPeerConnectionState state) {
+    // This function is the place to handle connection state changes for the room. States like
+    // ServiceRequestState.started could be handled here. It is currently handled through platform events which happen
+    // after the connection state changes, so this is fine as it is, but we could have a better granularigy if this was
+    // handled here.
+
     // REVIEW: Should the room expose the connection state (e.g. `isAgentStreamConnected`, `isExplorerStreamConnected`)?
     _log.info('connection state changed track_id=$trackId state=$state');
     if (RTCPeerConnectionState.RTCPeerConnectionStateFailed == state) {

--- a/lib/src/throttler.dart
+++ b/lib/src/throttler.dart
@@ -1,0 +1,18 @@
+class Throttler {
+  Throttler({this.delay = 1000});
+
+  final int delay;
+  DateTime _lastTimestamp = DateTime.fromMillisecondsSinceEpoch(0);
+
+  DateTime get lastTimestamp => _lastTimestamp;
+
+  bool get shouldThrottle {
+    DateTime now = DateTime.now();
+    if (now.difference(_lastTimestamp).inMilliseconds < delay) {
+      // Same throttling delay as `KurrentoRoom.updateLocation`.
+      return true;
+    }
+    _lastTimestamp = now;
+    return false;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 1.7.0
+version: 1.7.1
 homepage: https://github.com/aira-collab/flutter_aira
 
 environment:
@@ -21,7 +21,7 @@ dependencies:
   meta: ^1.8.0
   mqtt_client: ^9.8.0
   package_info_plus: ^3.0.2
-  pubnub: ^4.2.4
+  pubnub: ^4.3.0
 
 dev_dependencies:
   flutter_lints: ^2.0.3

--- a/test/throttler_test.dart
+++ b/test/throttler_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_aira/src/throttler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Throttler tests', ()
+  {
+    test('First call is never throttled', () async {
+      Throttler throttler = Throttler(delay: 50);
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(throttler.shouldThrottle, isFalse); // first call is always false
+    });
+
+    test('First call is never throttled even when called long after creation', () async {
+      Throttler throttler = Throttler(delay: 50);
+      await Future.delayed(const Duration(milliseconds: 75));
+      expect(throttler.shouldThrottle, isFalse); // first call is always false
+    });
+
+    test('Should Throttle with expected delay', () async {
+      Throttler throttler = Throttler(delay: 50);
+      expect(throttler.shouldThrottle, isFalse); // first call is always false
+      await Future.delayed(const Duration(milliseconds: 55));
+      expect(throttler.shouldThrottle, isFalse);
+      expect(throttler.shouldThrottle, isTrue); // second call is throttled
+      expect(throttler.shouldThrottle, isTrue);
+      await Future.delayed(const Duration(milliseconds: 30));
+      expect(throttler.shouldThrottle, isTrue);
+      await Future.delayed(const Duration(milliseconds: 21));
+      expect(throttler.shouldThrottle, isFalse);
+      expect(throttler.shouldThrottle, isTrue); // second call is throttled
+    });
+  });
+}


### PR DESCRIPTION
Since we are still getting a good amount of sentry error like the following:

> PlatformLocalizedException: The endpoint has been modified concurrently, and it has an exclusive lock. Please try again later

We have moved the maximum of location update request to one every 2 seconds.