### PR TITLE
feat: add `User.aiDailyMessageLimit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.11.0] - 2024-01-03
 ### New
 - `User.aiDailyMessageLimit` to determine how many AI image description requests an Explorer can make per day (#102)
-- `User.getAIDailyMessageLimitProperty` to retrieve property from `UserProperties` (#102)
 
 ## [1.10.1] - 2023-12-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2024-01-03
+### New
+- `User.aiDailyMessageLimit` to determine how many AI image description requests an Explorer can make per day (#102)
+- `User.getAIDailyMessageLimitProperty` to retrieve property from `UserProperties` (#102)
+
 ## [1.10.1] - 2023-12-28
 ### Changed
 - Updated plugin and pod dependencies for security and compatibility purposes (#101)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.11.0] - 2024-01-03
-### New
+### Added
 - `User.aiDailyMessageLimit` to determine how many AI image description requests an Explorer can make per day (#102)
 
 ## [1.10.1] - 2023-12-28

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,7 +204,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.10.0"
+    version: "1.11.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -11,7 +11,7 @@ class User {
   final List<Profile> profiles;
   final String? referralLink;
   final bool tosAccepted;
-  final int? aiDailyMessageLimit;
+  final int aiDailyMessageLimit;
 
   User({
     required this.id,
@@ -24,7 +24,7 @@ class User {
     required this.profiles,
     this.referralLink,
     required this.tosAccepted,
-    this.aiDailyMessageLimit,
+    required this.aiDailyMessageLimit,
   });
 
   User.fromJson(Map<String, dynamic> json)

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -11,6 +11,7 @@ class User {
   final List<Profile> profiles;
   final String? referralLink;
   final bool tosAccepted;
+  final String? aiDailyMessageLimit;
 
   User({
     required this.id,
@@ -23,6 +24,7 @@ class User {
     required this.profiles,
     this.referralLink,
     required this.tosAccepted,
+    this.aiDailyMessageLimit,
   });
 
   User.fromJson(Map<String, dynamic> json)
@@ -34,13 +36,13 @@ class User {
             .cast<Language>()
             .toList(growable: false),
         lastName = json['lastName'] ?? '',
-        linkedAccounts = (json['providers'] as List<dynamic>)
-            .map((json) => json['serviceName'] as String)
-            .toList(growable: false),
+        linkedAccounts =
+            (json['providers'] as List<dynamic>).map((json) => json['serviceName'] as String).toList(growable: false),
         phoneNumber = json['phoneNumber'],
         tosAccepted = json['tosAccepted'],
         profiles = (json['accounts'] as List<dynamic>).map((e) => Profile.fromJson(e)).toList(growable: false),
-        referralLink = json['referralLink'];
+        referralLink = json['referralLink'],
+        aiDailyMessageLimit = _getAIDailyMessageLimitProperty(json['properties']);
 
   /// Keeping immutability of the class while providing a way to clone new instances of User with different values.
   User cloneWith({
@@ -66,3 +68,6 @@ class User {
         tosAccepted: tosAccepted ?? this.tosAccepted,
       );
 }
+
+///Returns the value of the property [aiDailyMessageLimit] from the [json] object.
+String? _getAIDailyMessageLimitProperty(Map<String, dynamic> json) => (json['aiDailyMessageLimit']?.first?['value']);

--- a/lib/src/models/user.dart
+++ b/lib/src/models/user.dart
@@ -11,7 +11,7 @@ class User {
   final List<Profile> profiles;
   final String? referralLink;
   final bool tosAccepted;
-  final String? aiDailyMessageLimit;
+  final int? aiDailyMessageLimit;
 
   User({
     required this.id,
@@ -55,6 +55,8 @@ class User {
     String? phoneNumber,
     bool? tosAccepted,
     List<Profile>? profiles,
+    String? referralLink,
+    int? aiDailyMessageLimit,
   }) =>
       User(
         id: id ?? this.id,
@@ -66,8 +68,11 @@ class User {
         phoneNumber: phoneNumber ?? this.phoneNumber,
         profiles: profiles ?? this.profiles,
         tosAccepted: tosAccepted ?? this.tosAccepted,
+        referralLink: referralLink ?? this.referralLink,
+        aiDailyMessageLimit: aiDailyMessageLimit ?? this.aiDailyMessageLimit,
       );
 }
 
 ///Returns the value of the property [aiDailyMessageLimit] from the [json] object.
-String? _getAIDailyMessageLimitProperty(Map<String, dynamic> json) => (json['aiDailyMessageLimit']?.first?['value']);
+int _getAIDailyMessageLimitProperty(Map<String, dynamic> json) =>
+    int.tryParse(json['aiDailyMessageLimit']?.first?['value'] ?? '0') ?? 0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 1.10.1
+version: 1.11.0
 homepage: https://github.com/aira/flutter_aira
 
 environment:


### PR DESCRIPTION
We are adding a user property `aiDailyMessageLimit` that will determine how many AI image description requests an Explorer can make per day.