### PR TITLE
fix: fixed issue where calls could start without video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.12.2] - 2024-01-31
+## [1.12.2] - 2024-02-02
 ### Changed
 - Added a safety to give a second chance to transmit video in case the video track wasn't fully initialized at room join time. (#106)
+- Added a safety to make sure the participant status is updated properly if we join the room after the Service Request status is set to "started" (#106)
+- Added logging to help diagnose issues related to calls started without videos (#106)
 
 ## [1.12.1] - 2024-01-29
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.2] - 2024-01-31
+### Changed
+- Added a safety to give a second chance to transmit video in case the video track wasn't fully initialized at room join time. (#106)
+
 ## [1.12.1] - 2024-01-29
 ### Changed
-- Updated plugin and pod dependencies for security and compatibility purposes (#101)
+- Updated plugin and pod dependencies for security and compatibility purposes (#104)
 
 ## [1.12.0] - 2024-01-10
 ### Added

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,7 +204,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.12.1"
+    version: "1.12.2"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -621,7 +621,10 @@ class KurentoRoom extends ChangeNotifier implements Room {
           final bool hasOutgoingVideoSenderTrack = _connectionByTrackId[_localTrackId!]?.ownsVideoTrack != true;
           if (!_hasVideoTrack || !hasOutgoingVideoSenderTrack) {
             _log.shout(
-                'Starting a call without video. hasOutgoingVideoSenderTrack: $hasOutgoingVideoSenderTrack, _hasVideoTrack: $_hasVideoTrack');
+              'Starting a call without video. '
+              'hasOutgoingVideoSenderTrack: $hasOutgoingVideoSenderTrack, '
+              '_hasVideoTrack: $_hasVideoTrack',
+            );
           }
           // Now that the Agent has joined the room, publish our participant status.
           await _updateParticipantStatus();

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -618,13 +618,10 @@ class KurentoRoom extends ChangeNotifier implements Room {
           // Agent-initiated end message, but the impact of that is low (the Explorer can end the call themselves).
           _getServiceRequestStatusTimer?.cancel();
 
-          // HACK: In some cases, the video track isn't fully created at the time we join the room. This causes Agent
-          // Dashboard to behave as if the video is muted when it really isn't. So, if we have a video track and we're
-          // not muted, we want to make sure SFUConnection is transmitting that video.
-          final bool shouldTransmitVideo = _isVideoMuted == false && _hasVideoTrack;
-          if (shouldTransmitVideo && _connectionByTrackId[_localTrackId!]?.ownsVideoTrack != true) {
-            _log.warning('Attempting to re-create the video track');
-            await _setVideoMuted(_isVideoMuted);
+          final bool hasOutgoingVideoSenderTrack = _connectionByTrackId[_localTrackId!]?.ownsVideoTrack != true;
+          if (!_hasVideoTrack || !hasOutgoingVideoSenderTrack) {
+            _log.shout(
+                'Starting a call without video. hasOutgoingVideoSenderTrack: $hasOutgoingVideoSenderTrack, _hasVideoTrack: $_hasVideoTrack');
           }
           // Now that the Agent has joined the room, publish our participant status.
           await _updateParticipantStatus();

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -626,16 +626,14 @@ class KurentoRoom extends ChangeNotifier implements Room {
           // arise.
           final bool hasOutgoingVideoSenderTrack =
               null != _localTrackId && _connectionByTrackId[_localTrackId!]?.ownsVideoTrack == true;
-          if (!_hasVideoTrack || !hasOutgoingVideoSenderTrack) {
+          if (!_hasVideoTrack || !hasOutgoingVideoSenderTrack || isVideoMuted) {
             _log.shout(
               'Starting a call without video. '
               'hasOutgoingVideoSenderTrack: $hasOutgoingVideoSenderTrack, '
-              '_hasVideoTrack: $_hasVideoTrack'
-              '_localTrackId: ${null == _localTrackId ? 'null' : 'not null'}',
+              '_hasVideoTrack: $_hasVideoTrack, '
+              '_localTrackId: ${null == _localTrackId ? 'null' : 'not null'}, '
+              'isVideoMuted: $isVideoMuted',
             );
-          }
-          if (_isVideoMuted) {
-            _log.shout('Starting a call with video muted');
           }
 
           // Now that the Agent has joined the room, publish our participant status.

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -618,6 +618,14 @@ class KurentoRoom extends ChangeNotifier implements Room {
           // Agent-initiated end message, but the impact of that is low (the Explorer can end the call themselves).
           _getServiceRequestStatusTimer?.cancel();
 
+          // HACK: In some cases, the video track isn't fully created at the time we join the room. This causes Agent
+          // Dashboard to behave as if the video is muted when it really isn't. So, if we have a video track and we're
+          // not muted, we want to make sure SFUConnection is transmitting that video.
+          final bool shouldTransmitVideo = _isVideoMuted == false && _hasVideoTrack;
+          if (shouldTransmitVideo && _connectionByTrackId[_localTrackId!]?.ownsVideoTrack != true) {
+            _log.warning('Attempting to re-create the video track');
+            await _setVideoMuted(_isVideoMuted);
+          }
           // Now that the Agent has joined the room, publish our participant status.
           await _updateParticipantStatus();
         }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -285,6 +285,9 @@ class KurentoRoom extends ChangeNotifier implements Room {
   Future<void> join(MediaStream localStream) async {
     _localStream = localStream;
     await _createOutgoingTrack();
+    // Attempt to update the participant status just in case we succeed at
+    // joining the room after the ServiceRequest's status is set to "Started"
+    await _updateParticipantStatus();
   }
 
   @override
@@ -612,22 +615,42 @@ class KurentoRoom extends ChangeNotifier implements Room {
           await _updateServiceRequestStatus('ASSIGNED', agentFirstName);
         } else if (_serviceRequestState == ServiceRequestState.assigned) {
           _serviceRequestState = ServiceRequestState.started;
-          notifyListeners();
 
           // Once we've started, we no longer need the timer to consume resources. This means we may miss an
           // Agent-initiated end message, but the impact of that is low (the Explorer can end the call themselves).
           _getServiceRequestStatusTimer?.cancel();
 
-          final bool hasOutgoingVideoSenderTrack = _connectionByTrackId[_localTrackId!]?.ownsVideoTrack != true;
-          if (!_hasVideoTrack || !hasOutgoingVideoSenderTrack) {
+          // HACK: This condition is here to cover the improbable possibility
+          // that we would have join the room with a _localStream which didn't
+          // yet contain a video track. In this case, this code would replace
+          // the transceiver for another one containing the video track.
+          final bool shouldTransmitVideo = _isVideoMuted == false && _hasVideoTrack;
+          final bool hasOutgoingVideoSenderTrack = _connectionByTrackId[_localTrackId!]?.ownsVideoTrack == true;
+          if (null != _localTrackId && shouldTransmitVideo && !hasOutgoingVideoSenderTrack) {
+            _log.warning('Attempting to re-create the video track');
+            await _setVideoMuted(_isVideoMuted);
+          }
+
+          // Remove the follow logging once no longer needed.
+          // Some logging to help diagnose issues related to videos when they
+          // arise.
+          if (!_hasVideoTrack || !hasOutgoingVideoSenderTrack || null == _localTrackId) {
             _log.shout(
               'Starting a call without video. '
               'hasOutgoingVideoSenderTrack: $hasOutgoingVideoSenderTrack, '
-              '_hasVideoTrack: $_hasVideoTrack',
+              '_hasVideoTrack: $_hasVideoTrack'
+              '_localTrackId: ${null == _localTrackId ? 'null' : 'not null'}',
             );
           }
+          if (_isVideoMuted) {
+            _log.warning('Starting a call with video muted');
+          }
+
           // Now that the Agent has joined the room, publish our participant status.
           await _updateParticipantStatus();
+
+          // We want to notify Listeners after updating the participant Status.
+          notifyListeners();
         }
         break;
 

--- a/lib/src/sfu_connection.dart
+++ b/lib/src/sfu_connection.dart
@@ -114,6 +114,8 @@ class SfuConnection {
     }
   }
 
+  bool get ownsVideoTrack => _video.sender.track != null;
+
   Future<void> replaceVideoTrack(MediaStreamTrack? track) async {
     if (_isIncoming) {
       throw StateError('Cannot replace video track on incoming connection');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 1.12.1
+version: 1.12.2
 homepage: https://github.com/aira/flutter_aira
 
 environment:


### PR DESCRIPTION
# Description

This PR addresses the issue described [here](https://aira.slack.com/archives/C01LB57N74Z/p1706390196107819).

Here is the flow of events as a call start in a very simple form:

1. Client: Room.createServiceRequest is called.
2. Room: The service status request is both received from a RabbitMQ message and polled
3. Room: We get the Request ServiceRequest status and do nothing
4. Room: We get the Assigned ServiceRequest status and notify listeners. Step 5 & 6 happen concurrently.
5. Client: We create the video track and join the room (which is creating the video transceiver)
6. Room: Continues the connection process.
7. Room: We get the Started ServiceRequest status and update the ParticipantStatus and notify listeners.

Things to keep in mind as you continue this reading:

A) `Room.setVideoMute` does call `Room._updateParticipantStatus` but the later only executes if the ServiceRequest status is set to `Started`

B) `Room._updateParticipantStatus` will set the Participant status to `PRIVACY_AUDIO_ONLY` when `_isVideoMuted` is true or when `_hasVideoTrack` is false. In our case, we expect this is the later which causes the VI to see the video as muted as our Explorers say they did not mute the video. 

## Possibility no1:
We update the VideoMute status before we have the video which leads to a PRIVACY_AUDIO_ONLY participant status, which in turn causes the VI to see the "video muted" icon instead of the video.

It is unclear to me when the call to `Room.createServiceRequest` returns and this could vary on device types, concurrency condition, etc. I mention this because this is just when that function returns that we used to call `Room.setVideoMute` to set the starting mute status in Room. The question arise because of item A). So if the video was never muted on the client, we would need these condition to be true to cause the problem:

1. We don't have a video track yet.
2. The ServiceRequest Status is: Started

These conditions can only happen if the client has finished to create the video track and the ServiceRequest is now set to True.

## Possibility no2:
Could it be possible that the MediaStream gets created without video? Probably not as we wait for the call to `getMediaStream` (and all its wrapping functions) to complete, but nothing warranties that the video track is within the video tracks at that time. This would affect both the video mute status (see item B) and our ability to create an outgoing video transceiver (this is done as we join the room)

## Possibility no3:
Could it be possible that we join the room after the ServiceRequest status is set to "Started"? This could be possible if the time to create the video track is longer than the time for Agent Dashboard to be ready to receive. I didn't go through the whole code in Platform to figure out this possibility, but we do have this comment in `ServiceRequestManager`:  "// START is called once dashboard is loaded and ready to receive"
This would mean that the `_localStream` would be null when the ServiceRequest status is "Started".

## Proposed solution:
Lets address the 3 possibilities. Only the 2 last one can be resolved in Flutter_aira though.