### PR TITLE
chore: updated MQTT's WebSocket protocol for better support of newer RabbitMQ versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.1] - 2024-03-01
+## [2.1.2] - 2024-03-06
+### Changed
+- Updated mqtt's websocket protocol to align with newer version of RabbitMQ. This change is backward compatible. (#117)
 
+## [2.1.1] - 2024-03-01
 ### Changed
 - **BREAKING:** Renamed `authorFullName` to `authorFirstName` (#116)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.2] - 2024-03-06
 ### Changed
-- Updated mqtt's websocket protocol to align with newer version of RabbitMQ. This change is backward compatible. (#117)
+- Updated mqtt's websocket protocol to align with newer version of RabbitMQ. This change is backward compatible. (#118)
 
 ## [2.1.1] - 2024-03-01
 ### Changed

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -220,7 +220,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/src/platform_mq.dart
+++ b/lib/src/platform_mq.dart
@@ -39,7 +39,7 @@ class PlatformMQImpl implements PlatformMQ {
       ..autoReconnect = true
       ..keepAlivePeriod = 30
       ..setProtocolV311()
-      ..websocketProtocols = ['mqttv3.1.1']
+      ..websocketProtocols = ['mqtt']
       ..onAutoReconnect = _handleAutoReconnect
       ..onConnected = _handleConnected
       ..onSubscribed = _handleSubscribed
@@ -62,7 +62,12 @@ class PlatformMQImpl implements PlatformMQ {
     _client.published!.listen(_handleData);
   }
 
-  static Future<PlatformMQ> create(PlatformEnvironment env, Session session, {String? lastWillMessage, String? lastWillTopic}) async {
+  static Future<PlatformMQ> create(
+    PlatformEnvironment env,
+    Session session, {
+    String? lastWillMessage,
+    String? lastWillTopic,
+  }) async {
     PlatformMQImpl instance = PlatformMQImpl._(session);
     await instance._init(env, lastWillMessage: lastWillMessage, lastWillTopic: lastWillTopic);
     return instance;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/aira/flutter_aira
 
 environment:


### PR DESCRIPTION
Our effort to keep RabbitMQ up to date brought an incompatibility issue: 

> Maybe in the rabbitmq_web_mqtt v3.12.13 plugin there was a change on how incoming connections are handled

This PR changes that protocol and was tested with both the new version of RabbitMQ and the previous one to ensure backward compatibility