### PR TITLE
Allow server to specify the ice servers configuration

### DIFF
--- a/lib/src/models/service_request.dart
+++ b/lib/src/models/service_request.dart
@@ -19,6 +19,9 @@ class ServiceRequest {
   final int userId;
   final List<dynamic> stunServers;
   final List<dynamic> turnServers;
+  /// If iceService is not empty, it should be used instead of building the
+  /// ice server list from stunServers and turnServers.
+  final List<dynamic> iceServers;
 
   ServiceRequest.fromJson(Map<String, dynamic> json)
       : id = json['serviceId'],
@@ -26,5 +29,6 @@ class ServiceRequest {
         roomId = json['webrtcRoomId'],
         userId = json['userId'],
         stunServers = json['stunServers'],
-        turnServers = json['turnServers'];
+        turnServers = json['turnServers'],
+        iceServers = json['iceServers'] ?? [];
 }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -836,6 +836,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
       await connection.connect(
         _serviceRequest.stunServers,
         _serviceRequest.turnServers,
+        _serviceRequest.iceServers,
         incomingTrackKind: kind,
       );
     } else {
@@ -852,6 +853,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
       await connection.connect(
         _serviceRequest.stunServers,
         _serviceRequest.turnServers,
+        _serviceRequest.iceServers,
         outgoingAudioTrack: outgoingAudioTrack,
         outgoingVideoTrack: outgoingVideoTrack,
       );


### PR DESCRIPTION
Currently, the final ice servers used for a peer connection are determined by a list of stun and turn servers provided by platform, which are then conveted into a list of ice servers on the client.

The current setup gives the server limited control over how the final ice servers are calculated.

This change allows platform to return a field "iceServers", which take presedence over the stunServer and turnServer fields, if specified. When the field is not populated by platform, the app continues to use the old logic.

This change allows us to experiment with different turn services such as cloudflare's turn service or registering tcp URLs for the turn server by changing server side logic only.