### PR TITLE
Multiple agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.2] - 2024-08-22
+### Add
+- Enabled support of multiple agents video in a call
+### Fix
+- Made track kind detection null-empty aware
+
+
 ## [2.14.1] - 2024-08-22
 ### Changed
 - `accessAi` property was renamed to `accessAiRestrictions` and updated to be nullable.(#138)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -548,8 +548,8 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
       progressSetState!(() => progressText = 'Waiting for an Aira Agent...');
       _room!.addListener(() {
         if (_room!.serviceRequestState == ServiceRequestState.assigned) {
-          progressSetState!(() =>
-              progressText = 'Connecting to Agent ${_room!.agentsNames}...');
+          progressSetState!(() => progressText =
+              'Connecting to Agent ${_room!.agentsNames.values.lastOrNull.toString()}...');
         } else if (_room!.serviceRequestState == ServiceRequestState.started) {
           // Close the call progress dialog.
           Navigator.pop(context);
@@ -557,7 +557,8 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
           // Rebuild the UI.
           setState(() {});
 
-          _showSnackBar('Connected to Agent ${_room!.agentsNames}');
+          _showSnackBar(
+              'Connected to Agent ${_room!.agentsNames.values.lastOrNull}');
         } else if (_room!.serviceRequestState == ServiceRequestState.ended) {
           // The call was ended by the Agent or Platform, so hang up.
           _hangUp();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -549,7 +549,7 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
       _room!.addListener(() {
         if (_room!.serviceRequestState == ServiceRequestState.assigned) {
           progressSetState!(() => progressText =
-              'Connecting to Agent ${_room!.agentsNames.values.lastOrNull.toString()}...');
+              'Connecting to Agent ${_room!.agentsName.values.lastOrNull.toString()}...');
         } else if (_room!.serviceRequestState == ServiceRequestState.started) {
           // Close the call progress dialog.
           Navigator.pop(context);
@@ -558,7 +558,7 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
           setState(() {});
 
           _showSnackBar(
-              'Connected to Agent ${_room!.agentsNames.values.lastOrNull}');
+              'Connected to Agent ${_room!.agentsName.values.lastOrNull}');
         } else if (_room!.serviceRequestState == ServiceRequestState.ended) {
           // The call was ended by the Agent or Platform, so hang up.
           _hangUp();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -549,7 +549,7 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
       _room!.addListener(() {
         if (_room!.serviceRequestState == ServiceRequestState.assigned) {
           progressSetState!(() =>
-              progressText = 'Connecting to Agent ${_room!.agentName}...');
+              progressText = 'Connecting to Agent ${_room!.agentsNames}...');
         } else if (_room!.serviceRequestState == ServiceRequestState.started) {
           // Close the call progress dialog.
           Navigator.pop(context);
@@ -557,7 +557,7 @@ class _MyAppState extends State<MyApp> implements RoomHandler {
           // Rebuild the UI.
           setState(() {});
 
-          _showSnackBar('Connected to Agent ${_room!.agentName}');
+          _showSnackBar('Connected to Agent ${_room!.agentsNames}');
         } else if (_room!.serviceRequestState == ServiceRequestState.ended) {
           // The call was ended by the Agent or Platform, so hang up.
           _hangUp();

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: ">3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/lib/src/extension/string_extension.dart
+++ b/lib/src/extension/string_extension.dart
@@ -1,0 +1,3 @@
+extension StringManipulation on String? {
+  bool get isNotNullOrEmpty => this != null && this!.isNotEmpty;
+}

--- a/lib/src/models/track.dart
+++ b/lib/src/models/track.dart
@@ -16,8 +16,8 @@ class Track {
   // determining kind of incoming track based on nullity check of audio and video type
   // only one is not null for incoming track
   TrackKind? get kind {
-    if (audioType != null) return TrackKind.audio;
-    if (videoType != null) return TrackKind.video;
+    if (audioType != null && audioType!.isNotEmpty) return TrackKind.audio;
+    if (videoType != null && videoType!.isNotEmpty) return TrackKind.video;
     return null;
   }
 

--- a/lib/src/models/track.dart
+++ b/lib/src/models/track.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_aira/src/extension/string_extension.dart';
+
 class Track {
   int id;
   int participantId;
@@ -14,10 +16,10 @@ class Track {
         videoType = json['video'];
 
   // determining kind of incoming track based on nullity check of audio and video type
-  // only one is not null for incoming track
+  // only one is not null for ``incoming track``
   TrackKind? get kind {
-    if (audioType != null && audioType!.isNotEmpty) return TrackKind.audio;
-    if (videoType != null && videoType!.isNotEmpty) return TrackKind.video;
+    if (audioType.isNotNullOrEmpty) return TrackKind.audio;
+    if (videoType.isNotNullOrEmpty) return TrackKind.video;
     return null;
   }
 

--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -400,6 +400,7 @@ class PlatformClient {
           .split(' ')
           .first, // Split the first name and last initial.
       'status': response['serviceStatus'],
+      'agentId': response['agentId'].toString()
     };
   }
 

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1100,10 +1100,14 @@ class KurentoRoom extends ChangeNotifier implements Room {
       for (SfuConnection connection in _connectionByTrackId.values) {
         await connection.dispose();
       }
+
+      _connectionByTrackId.keys.forEach((trackId) async {
+        await _roomHandler.removeRemoteStream(trackId);
+      });
+
       _connectionByTrackId.clear();
       _incomingTrackIdByOutgoingTrackId.clear();
       _tracksByAgentId.clear();
-
       // Create and connect new tracks to receive the remote streams from the other participant(s). (Do this before our
       // local stream, since we want to be able to hear the Agent ASAP.)
       for (Participant participant

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -157,7 +157,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
 
   bool get _isPresenting => null != _presentationStream;
   ServiceRequestState _serviceRequestState = ServiceRequestState.queued;
-  final Map<String, String> _agentsNames = {};
+  final Map<String, String> _agentsName = {};
 
   MediaStream? _localStream;
   int? _localTrackId;
@@ -291,7 +291,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
   ServiceRequestState get serviceRequestState => _serviceRequestState;
 
   @override
-  Map<String, String> get agentsName => _agentsNames;
+  Map<String, String> get agentsName => _agentsName;
 
   @override
   bool get isAudioMuted => _isAudioMuted;
@@ -759,11 +759,11 @@ class KurentoRoom extends ChangeNotifier implements Room {
       case 'ASSIGNED':
         if (_serviceRequestState == ServiceRequestState.queued) {
           _serviceRequestState = ServiceRequestState.assigned;
-          _agentsNames[agentId!] = agentFirstName!;
+          _agentsName[agentId!] = agentFirstName!;
           notifyListeners();
           break;
         }
-        _agentsNames[agentId!] = agentFirstName!;
+        _agentsName[agentId!] = agentFirstName!;
         break;
 
       case 'STARTED':
@@ -807,7 +807,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
         break;
       // Handles the case when the Agent leaves the room on a call transfer, name is turned to null to represent that agent is no longer in the call
       case 'LEFT':
-        _agentsNames.remove(agentId.toString());
+        _agentsName.remove(agentId.toString());
         final tracks = _tracksByAgentId[agentId];
         tracks?.forEach((trackId) async {
           await _roomHandler.removeRemoteStream(trackId);

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -939,12 +939,8 @@ class KurentoRoom extends ChangeNotifier implements Room {
   Future<void> _handleTrack(int trackId, RTCTrackEvent event) async {
     await _roomHandler.addRemoteStream(trackId, event.streams[0]);
     // adds latest incoming tracks to the last agent
-    final currentAgent = agentsNames.keys.last;
-    if (_tracksByAgentId[currentAgent] == null) {
-      _tracksByAgentId[currentAgent] = [trackId];
-    } else {
-      _tracksByAgentId[currentAgent]!.add(trackId);
-    }
+    final currentAgentId = agentsNames.keys.last;
+    _tracksByAgentId.putIfAbsent(currentAgentId, () => []).add(trackId);
   }
 
   Future<void> _updateParticipantStatus() async {

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_aira/flutter_aira.dart';
@@ -68,7 +69,7 @@ abstract class Room implements Listenable {
   /// The name of the Agent assigned to the service request.
   ///
   /// If the service request has not yet been assigned, this will return `null`.
-  String? get agentName;
+  Map<String, String> get agentsNames;
 
   /// Getter providing the [MessagingClient].
   ///
@@ -145,6 +146,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
 
   final Map<int, SfuConnection> _connectionByTrackId = {};
   final Map<int, int> _incomingTrackIdByOutgoingTrackId = {};
+  final Map<String, List<int>> _tracksByAgentId = {};
 
   bool _isDisposed = false;
   bool _isAudioMuted = false;
@@ -155,7 +157,8 @@ class KurentoRoom extends ChangeNotifier implements Room {
 
   bool get _isPresenting => null != _presentationStream;
   ServiceRequestState _serviceRequestState = ServiceRequestState.queued;
-  String? _agentName;
+  final Map<String, String> _agentsNames = {};
+
   MediaStream? _localStream;
   int? _localTrackId;
   Timer? _getServiceRequestStatusTimer;
@@ -288,7 +291,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
   ServiceRequestState get serviceRequestState => _serviceRequestState;
 
   @override
-  String? get agentName => _agentName;
+  Map<String, String> get agentsNames => _agentsNames;
 
   @override
   bool get isAudioMuted => _isAudioMuted;
@@ -687,7 +690,6 @@ class KurentoRoom extends ChangeNotifier implements Room {
               'type=${participantMessage.type} track_id=${participantMessage.trackId}');
         }
         break;
-
       case ParticipantMessageType.INCOMING_TRACK_CREATE:
         await _createIncomingTrack(
           participantMessage.trackId,
@@ -727,6 +729,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
     await _updateServiceRequestStatus(
       response['status']!,
       response['agentFirstName'],
+      response['agentId'],
     );
   }
 
@@ -734,12 +737,17 @@ class KurentoRoom extends ChangeNotifier implements Room {
     Map<String, dynamic> json = jsonDecode(message);
     if (json['id'] != _serviceRequest.id) return;
 
-    await _updateServiceRequestStatus(json['status'], json['agentFirstName']);
+    await _updateServiceRequestStatus(
+      json['status'],
+      json['agentFirstName'],
+      json['agentId'].toString(),
+    );
   }
 
   Future<void> _updateServiceRequestStatus(
     String status,
     String? agentFirstName,
+    String? agentId,
   ) async {
     _log.info('updating service request status=$status');
 
@@ -751,9 +759,11 @@ class KurentoRoom extends ChangeNotifier implements Room {
       case 'ASSIGNED':
         if (_serviceRequestState == ServiceRequestState.queued) {
           _serviceRequestState = ServiceRequestState.assigned;
-          _agentName = agentFirstName;
+          _agentsNames[agentId!] = agentFirstName!;
           notifyListeners();
+          break;
         }
+        _agentsNames[agentId!] = agentFirstName!;
         break;
 
       case 'STARTED':
@@ -763,7 +773,11 @@ class KurentoRoom extends ChangeNotifier implements Room {
           _log.warning(
             'missed service request status message topic=$_serviceRequestPresenceTopic',
           );
-          await _updateServiceRequestStatus('ASSIGNED', agentFirstName);
+          await _updateServiceRequestStatus(
+            'ASSIGNED',
+            agentFirstName,
+            agentId,
+          );
         } else if (_serviceRequestState == ServiceRequestState.assigned) {
           _serviceRequestState = ServiceRequestState.started;
           notifyListeners();
@@ -793,7 +807,11 @@ class KurentoRoom extends ChangeNotifier implements Room {
         break;
       // Handles the case when the Agent leaves the room on a call transfer, name is turned to null to represent that agent is no longer in the call
       case 'LEFT':
-        _agentName = null;
+        _agentsNames.remove(agentId.toString());
+        final tracks = _tracksByAgentId[agentId];
+        tracks?.forEach((trackId) async {
+          await _roomHandler.removeRemoteStream(trackId);
+        });
         notifyListeners();
         break;
 
@@ -819,6 +837,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
       // We've already connected the track.
       return;
     }
+
     SfuConnection connection = SfuConnection(
       direction: stream != null
           ? SfuConnectionDirection.outgoing
@@ -919,6 +938,13 @@ class KurentoRoom extends ChangeNotifier implements Room {
 
   Future<void> _handleTrack(int trackId, RTCTrackEvent event) async {
     await _roomHandler.addRemoteStream(trackId, event.streams[0]);
+    // adds latest incoming tracks to the last agent
+    final currentAgent = agentsNames.keys.last;
+    if (_tracksByAgentId[currentAgent] == null) {
+      _tracksByAgentId[currentAgent] = [trackId];
+    } else {
+      _tracksByAgentId[currentAgent]!.add(trackId);
+    }
   }
 
   Future<void> _updateParticipantStatus() async {
@@ -1004,7 +1030,6 @@ class KurentoRoom extends ChangeNotifier implements Room {
     _log.info('created outgoing track id=${track.id}');
 
     _localTrackId = track.id;
-
     await _connectTrack(
       _localTrackId!,
       _isPresenting ? _presentationStream : _localStream,
@@ -1041,7 +1066,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
       return;
     }
     await _roomHandler.removeRemoteStream(incomingTrackId);
-
+    _removeTracksByAgent(incomingTrackId);
     SfuConnection? connection = _connectionByTrackId.remove(incomingTrackId);
     if (connection != null) {
       await connection.dispose();
@@ -1081,6 +1106,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
       }
       _connectionByTrackId.clear();
       _incomingTrackIdByOutgoingTrackId.clear();
+      _tracksByAgentId.clear();
 
       // Create and connect new tracks to receive the remote streams from the other participant(s). (Do this before our
       // local stream, since we want to be able to hear the Agent ASAP.)
@@ -1106,5 +1132,11 @@ class KurentoRoom extends ChangeNotifier implements Room {
     } finally {
       _isReconnecting = false;
     }
+  }
+
+  void _removeTracksByAgent(int incomingTrackId) {
+    _tracksByAgentId.removeWhere((key, value) {
+      return value.firstWhereOrNull((item) => item == incomingTrackId) != null;
+    });
   }
 }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -808,10 +808,11 @@ class KurentoRoom extends ChangeNotifier implements Room {
       // Handles the case when the Agent leaves the room on a call transfer, name is turned to null to represent that agent is no longer in the call
       case 'LEFT':
         _agentsName.remove(agentId.toString());
-        final tracks = _tracksByAgentId[agentId];
-        tracks?.forEach((trackId) async {
+        final trackIds = _tracksByAgentId[agentId];
+        for (var trackId in trackIds!) {
           await _roomHandler.removeRemoteStream(trackId);
-        });
+          _removeTracksOfAgent(trackId);
+        }
         notifyListeners();
         break;
 
@@ -1062,7 +1063,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
       return;
     }
     await _roomHandler.removeRemoteStream(incomingTrackId);
-    _removeTracksByAgent(incomingTrackId);
+    _removeTracksOfAgent(incomingTrackId);
     SfuConnection? connection = _connectionByTrackId.remove(incomingTrackId);
     if (connection != null) {
       await connection.dispose();
@@ -1134,7 +1135,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
     }
   }
 
-  void _removeTracksByAgent(int incomingTrackId) {
+  void _removeTracksOfAgent(int incomingTrackId) {
     _tracksByAgentId.removeWhere((key, value) {
       return value.contains(incomingTrackId);
     });

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1136,7 +1136,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
 
   void _removeTracksByAgent(int incomingTrackId) {
     _tracksByAgentId.removeWhere((key, value) {
-      return value.firstWhereOrNull((item) => item == incomingTrackId) != null;
+      return value.contains(incomingTrackId);
     });
   }
 }

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -69,7 +69,7 @@ abstract class Room implements Listenable {
   /// The name of the Agent assigned to the service request.
   ///
   /// If the service request has not yet been assigned, this will return `null`.
-  Map<String, String> get agentsNames;
+  Map<String, String> get agentsName;
 
   /// Getter providing the [MessagingClient].
   ///
@@ -291,7 +291,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
   ServiceRequestState get serviceRequestState => _serviceRequestState;
 
   @override
-  Map<String, String> get agentsNames => _agentsNames;
+  Map<String, String> get agentsName => _agentsNames;
 
   @override
   bool get isAudioMuted => _isAudioMuted;
@@ -939,7 +939,7 @@ class KurentoRoom extends ChangeNotifier implements Room {
   Future<void> _handleTrack(int trackId, RTCTrackEvent event) async {
     await _roomHandler.addRemoteStream(trackId, event.streams[0]);
     // adds latest incoming tracks to the last agent
-    final currentAgentId = agentsNames.keys.last;
+    final currentAgentId = agentsName.keys.last;
     _tracksByAgentId.putIfAbsent(currentAgentId, () => []).add(trackId);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 2.14.1
+version: 2.14.2
 homepage: https://github.com/aira/flutter_aira
 
 environment:


### PR DESCRIPTION
This adds feature to manage multiple agents tracks while doing Transfer call, including:

- Adds agents track to memory by agentId while agent joins.
- Removes the agent track when an agent leaves the call.


#### Conclusion: 
This makes Explorer or ASL app to have control over tracks. resulting in less memory usage than before as well as switching between agents video track when an agent leaves during the transfer call.