### PR TITLE
Limit access ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.14.0] - 2024-08-19
+### Added
+- Add new property `accessAi` to User's Account. (#137)
+- `AccessAi` enum was added to the Account. (#137)
+
+
 ## [2.13.0] - 2024-08-09
 
 - Add new properties `googleEmail` and `appleEmail` to User.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -299,18 +299,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -347,18 +347,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mqtt_client:
     dependency: transitive
     description:
@@ -584,10 +584,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -624,10 +624,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
   web:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -220,7 +220,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.13.0"
+    version: "2.14.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/lib/flutter_aira.dart
+++ b/lib/flutter_aira.dart
@@ -7,7 +7,7 @@ export 'src/models/access_offer.dart'
         AccountDetails,
         SiteAddress,
         AccessOfferGPSResponse;
-export 'src/models/account.dart' show Account, AccountType;
+export 'src/models/account.dart' show Account, AccessAi, AccountType;
 export 'src/models/billing_info.dart' show PartialBillingInformation;
 export 'src/models/callHistory/build_ai.dart'
     show BuildAi, BuildAiStatus, NotAllowSharingReason;

--- a/lib/src/models/account.dart
+++ b/lib/src/models/account.dart
@@ -15,13 +15,35 @@ enum AccountType {
   }
 }
 
+enum AccessAi {
+  fullAccess('FULL_ACCESS'),
+  noHistory('NO_HISTORY'),
+  noAccess('NO_ACCESS');
+
+  final String value;
+
+  const AccessAi(this.value);
+
+  /// Gets the [AccessAi] from the given value.
+  ///
+  /// If the value is not found, [noAccess] is returned.
+  static AccessAi fromValue(String? value) {
+    return AccessAi.values
+        .firstWhere((e) => e.value == value, orElse: () => AccessAi.noAccess);
+  }
+}
+
 class Account {
   final int id;
   final String name;
   final AccountType type;
 
+  ///The Account(Profile) access limitations to AccessAI.
+  final AccessAi? accessAI;
+
   Account.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
-        type = AccountType.fromName(json['accountType']);
+        type = AccountType.fromName(json['accountType']),
+        accessAI = AccessAi.fromValue(json['accessAi']);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 2.13.0
+version: 2.14.0
 homepage: https://github.com/aira/flutter_aira
 
 environment:


### PR DESCRIPTION
Added a new accessAi property to the User's Account (Profile) data.

**Details**
Introduced the accessAi property to the User's Account (Profile) model.
This property is intended to manage Access AI permissions to different user's profiles.

**Example**:
A response example including the new `accessAi` property can be found in the following [issue](https://linear.app/airaio/issue/PLAT-269/limit-access-ai-platform-add-support-for-explorer-app#comment-b851829b). 