### PR TITLE
Fix API exception parser

### DIFF
--- a/lib/src/platform_client.dart
+++ b/lib/src/platform_client.dart
@@ -1503,7 +1503,7 @@ class PlatformClient {
     if (errorCode == 'SEC-001') {
       return const PlatformInvalidTokenException();
     }
-    final errorMessage = json['response']?['errorMessage'];
+    final errorMessage = json['response']?['errorMessage'] as String? ?? '';
     final metadataConnection = json['metadata']?['connection'];
     if (errorCode == 'AIRA-ACCESS-017' && metadataConnection != null) {
       return PlatformBusinessLoginRequiredException(
@@ -1515,7 +1515,7 @@ class PlatformClient {
     if (errorCode == 'KN-UM-065') {
       return PlatformDeleteAccountException(errorCode, errorMessage);
     }
-    if (json['response']?['errorMessage'] != null) {
+    if (errorMessage.isNotEmpty) {
       return PlatformLocalizedException(errorCode, errorMessage);
     }
     return PlatformUnknownException('Platform returned unexpected body: $body');

--- a/test/src/platform_client_test.dart
+++ b/test/src/platform_client_test.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+
+import 'package:flutter_aira/flutter_aira.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PlatformClient', () {
+    group('getExceptionFromApiResponse', () {
+      test('should return null if status SUCCESS', () {
+        final json = {
+          'response': {'status': 'SUCCESS'},
+        };
+        final e = PlatformClient.getExceptionFromApiResponse(
+          json: json,
+          body: jsonEncode(json),
+        );
+        expect(e, isNull);
+      });
+
+      test(
+          'should return PlatformInvalidTokenException if errorCode is SEC-001',
+          () {
+        final json = {
+          'response': {'errorMessage': 'error-msg', 'errorCode': 'SEC-001'},
+        };
+        final e = PlatformClient.getExceptionFromApiResponse(
+          json: json,
+          body: jsonEncode(json),
+        );
+        expect(e, isA<PlatformInvalidTokenException>());
+      });
+
+      test(
+          'should return PlatformBusinessLoginRequiredException if errorCode is AIRA-ACCESS-017 and connection is not null',
+          () {
+        final json = {
+          'response': {
+            'errorMessage': 'error-msg',
+            'errorCode': 'AIRA-ACCESS-017',
+          },
+          'metadata': {'connection': 'some-value'},
+        };
+        final e = PlatformClient.getExceptionFromApiResponse(
+          json: json,
+          body: jsonEncode(json),
+        );
+        expect(e, isA<PlatformBusinessLoginRequiredException>());
+        if (e is PlatformBusinessLoginRequiredException) {
+          expect(e.code, 'AIRA-ACCESS-017');
+          expect(e.toString(), 'error-msg');
+          expect(e.connection, 'some-value');
+        }
+
+        final jsonWithEmptyConnection = {
+          'response': {
+            'errorMessage': 'error-msg',
+            'errorCode': 'AIRA-ACCESS-017',
+          },
+          'metadata': {'connection': ''},
+        };
+        final e2 = PlatformClient.getExceptionFromApiResponse(
+          json: jsonWithEmptyConnection,
+          body: jsonEncode(jsonWithEmptyConnection),
+        );
+        expect(e2, isA<PlatformBusinessLoginRequiredException>());
+        if (e2 is PlatformBusinessLoginRequiredException) {
+          expect(e2.code, 'AIRA-ACCESS-017');
+          expect(e2.toString(), 'error-msg');
+          expect(e2.connection, isEmpty);
+        }
+      });
+
+      test(
+          'should return PlatformDeleteAccountException if errorCode is KN-UM-065',
+          () {
+        final json = {
+          'response': {
+            'errorCode': 'KN-UM-065',
+            'errorMessage': 'error-msg',
+          },
+        };
+        final e = PlatformClient.getExceptionFromApiResponse(
+          json: json,
+          body: jsonEncode(json),
+        );
+        expect(e, isA<PlatformDeleteAccountException>());
+        if (e is PlatformDeleteAccountException) {
+          expect(e.code, 'KN-UM-065');
+          expect(e.toString(), 'error-msg');
+        }
+      });
+
+      test(
+          'should return PlatformLocalizedException if errorMessage is not null',
+          () {
+        final json = {
+          'response': {
+            'errorCode': 'KN-UM-065',
+            'errorMessage': '',
+          },
+        };
+        final e = PlatformClient.getExceptionFromApiResponse(
+          json: json,
+          body: jsonEncode(json),
+        );
+        expect(e, isA<PlatformLocalizedException>());
+        if (e is PlatformLocalizedException) {
+          expect(e.code, 'KN-UM-065');
+          expect(e.toString(), isEmpty);
+        }
+      });
+    });
+
+    test('should return PlatformUnknownException if status not success', () {
+      final json = {
+        'response': {'status': 'FAILURE'},
+      };
+      final e = PlatformClient.getExceptionFromApiResponse(
+        json: json,
+        body: jsonEncode(json),
+      );
+      expect(e, isA<PlatformUnknownException>());
+      if (e is PlatformUnknownException) {
+        final body = jsonEncode(json);
+        expect(e.toString(), 'Platform returned unexpected body: $body');
+      }
+    });
+  });
+}

--- a/test/src/platform_client_test.dart
+++ b/test/src/platform_client_test.dart
@@ -91,12 +91,12 @@ void main() {
       });
 
       test(
-          'should return PlatformLocalizedException if errorMessage is not null',
+          'should return PlatformLocalizedException if errorMessage is not empty',
           () {
         final json = {
           'response': {
-            'errorCode': 'KN-UM-065',
-            'errorMessage': '',
+            'errorCode': 'some-error-code',
+            'errorMessage': 'non-empty-error-message',
           },
         };
         final e = PlatformClient.getExceptionFromApiResponse(
@@ -105,8 +105,8 @@ void main() {
         );
         expect(e, isA<PlatformLocalizedException>());
         if (e is PlatformLocalizedException) {
-          expect(e.code, 'KN-UM-065');
-          expect(e.toString(), isEmpty);
+          expect(e.code, 'some-error-code');
+          expect(e.toString(), 'non-empty-error-message');
         }
       });
     });


### PR DESCRIPTION
Only return `PlatformLocalizedException` when `errorMessage` is not empty.

existing behavior:
when `errorMessage` from API response is empty string, it will throw `PlatformLocalizedException`.

expected behavior:
when `errorMessage` from API response is empty or null, it should throw `PlatformUnknownException`.

try to handle response from "https://dev-platform.aira.io/api/user/location" has empty(non-null) errorMessage when it's not `SUCCESS`.
![image](https://github.com/user-attachments/assets/2e36e74d-3cec-4e2d-a74a-c5cc40d9defc)
