### PR TITLE
Allow a wider range of `flutter_webrtc` dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_webrtc: >=0.10.6
+  flutter_webrtc: ">=0.10.6"
   http: ^1.2.0
   intl: ^0.19.0
   logging: ^1.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   mqtt_client: ^10.2.0
   mutex: ^3.1.0
   package_info_plus: ^8.0.0
-  webrtc_interface: 1.2.0
+  webrtc_interface: ">=1.2.0"
 
 dev_dependencies:
   flutter_lints: ^3.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_webrtc: 0.10.6
+  flutter_webrtc: >=0.10.6
   http: ^1.2.0
   intl: ^0.19.0
   logging: ^1.2.0


### PR DESCRIPTION
Current limitation on `pubspec.yaml` does not allow `flutter_webrtc` to resolve to any higher number. In `explorer-ui` for web, we want to use a later version of `flutter_webrtc`.