### PR TITLE
Add Feedback rating option

### DIFF
--- a/lib/src/models/feedback.dart
+++ b/lib/src/models/feedback.dart
@@ -54,11 +54,4 @@ class Feedback {
       'rating': rating?.value,
     };
   }
-
-  bool? toYesNo() {
-    if (rating == null) return null;
-    if (rating == Rating.excellent) return true;
-    if (rating == Rating.disappointed) return false;
-    return null;
-  }
 }

--- a/lib/src/models/feedback.dart
+++ b/lib/src/models/feedback.dart
@@ -3,7 +3,7 @@ enum Rating {
   positive(1),
   neutral(0),
   negative(-1),
-  disappointed(-2);
+  terrible(-2);
 
   final int _value;
 
@@ -25,7 +25,7 @@ enum Rating {
       case -1:
         return negative;
       case -2:
-        return disappointed;
+        return terrible;
     }
     throw 'Unsupported Rating value: $value';
   }

--- a/lib/src/models/feedback.dart
+++ b/lib/src/models/feedback.dart
@@ -30,6 +30,24 @@ enum Rating {
     throw 'Unsupported Rating value: $value';
   }
 
+  static Rating? fromStars(int? stars) {
+    if (stars == null) return null;
+    switch (stars) {
+      case 1:
+        return Rating.terrible; // Maps to -2 (most negative)
+      case 2:
+        return Rating.negative; // Maps to -1
+      case 3:
+        return Rating.neutral; // Maps to 0 (neutral)
+      case 4:
+        return Rating.positive; // Maps to +1 (positive)
+      case 5:
+        return Rating.excellent; // Maps to +2 (most positive)
+      default:
+        throw ArgumentError('Invalid star rating: $stars');
+    }
+  }
+
   String get name => toString().split('.').last;
 }
 

--- a/lib/src/models/feedback.dart
+++ b/lib/src/models/feedback.dart
@@ -2,12 +2,15 @@ enum Rating {
   excellent(2),
   positive(1),
   neutral(0),
-  negative(-1);
+  negative(-1),
+  disappointed(-2);
 
   final int _value;
+
   const Rating(this._value);
 
   int get value => _value;
+
   static Rating? fromValue(int? value) {
     if (null == value) {
       return null;
@@ -21,6 +24,8 @@ enum Rating {
         return neutral;
       case -1:
         return negative;
+      case -2:
+        return disappointed;
     }
     throw 'Unsupported Rating value: $value';
   }
@@ -48,5 +53,12 @@ class Feedback {
       'comment': comment,
       'rating': rating?.value,
     };
+  }
+
+  bool? toYesNo() {
+    if (rating == null) return null;
+    if (rating == Rating.excellent) return true;
+    if (rating == Rating.disappointed) return false;
+    return null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_aira
 description: The Aira Flutter SDK.
-version: 3.2.2
+version: 3.3.2
 homepage: https://github.com/aira/flutter_aira
 
 environment:


### PR DESCRIPTION
This pull request adds a new `disappointed` rating to the `Rating` enum and introduces a utility method to map ratings to a yes/no value. The changes also update the package version to `3.3.2`.

**Feedback rating enhancements:**

* Added a new `disappointed` value to the `Rating` enum, representing a stronger negative sentiment.
* Updated the `fromValue` static method in `Rating` to support the new `disappointed` value.
* Added a `toYesNo()` method to the `Feedback` class to map `excellent` ratings to `true`, `disappointed` ratings to `false`, and other ratings to `null`.

**Version update:**

* Bumped the package version from `3.2.2` to `3.3.2` in `pubspec.yaml`.